### PR TITLE
[FIXED JENKINS-20235 JENKINS-20006] Configurable default view

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
@@ -46,6 +46,7 @@ import hudson.model.ItemGroupMixIn;
 import hudson.model.ItemVisitor;
 import hudson.model.Items;
 import hudson.model.Job;
+import hudson.model.AllView;
 import hudson.model.ListView;
 import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
@@ -264,24 +265,31 @@ public class Folder extends AbstractItem
         for (FolderProperty p : properties) {
             p.setOwner(this);
         }
-        if (columns == null) {
-            columns = new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(this,
-                    ListViewColumn.createDefaultInitialColumnList());
-        }
-        if (filters == null) {
-            filters = new DescribableList<ViewJobFilter, Descriptor<ViewJobFilter>>(this);
-        }
         if (views == null) {
             views = new CopyOnWriteArrayList<View>();
         }
         if (views.size() == 0) {
-            ListView lv = new ListView("All", this);
-            views.add(lv);
             try {
-                lv.getColumns().replaceBy(columns.toList());
-                lv.getJobFilters().replaceBy(filters.toList());
-                lv.setIncludeRegex(".*");
-                lv.save();
+                if (columns != null || filters != null) {
+                    // we're loading an ancient config
+                    if (columns == null) {
+                        columns = new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(this,
+                                ListViewColumn.createDefaultInitialColumnList());
+                    }
+                    if (filters == null) {
+                        filters = new DescribableList<ViewJobFilter, Descriptor<ViewJobFilter>>(this);
+                    }
+                    ListView lv = new ListView("All", this);
+                    views.add(lv);
+                    lv.getColumns().replaceBy(columns.toList());
+                    lv.getJobFilters().replaceBy(filters.toList());
+                    lv.setIncludeRegex(".*");
+                    lv.save();
+                } else {
+                    AllView v = new AllView("All", this);
+                    views.add(v);
+                    v.save();
+                }
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to set up the initial view", e);
             }
@@ -467,7 +475,8 @@ public class Folder extends AbstractItem
      *             Folder is no longer a view by itself.
      */
     public DescribableList<ListViewColumn, Descriptor<ListViewColumn>> getColumns() {
-        return columns;
+        return new DescribableList<ListViewColumn, Descriptor<ListViewColumn>>(this,
+                ListViewColumn.createDefaultInitialColumnList());
     }
 
     /**
@@ -688,6 +697,10 @@ public class Folder extends AbstractItem
 
         description = json.getString("description");
         displayName = Util.fixEmpty(json.optString("displayNameOrNull"));
+
+        if (json.has("primaryView")) {
+            setPrimaryView(viewGroupMixIn.getView(json.getString("primaryView")));
+        }
 
         properties.rebuild(req, json, getDescriptor().getPropertyDescriptors());
         for (FolderProperty p : properties) // TODO: push this to the subtype of property descriptors

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/Folder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/Folder/configure.jelly
@@ -42,6 +42,23 @@ THE SOFTWARE.
           <f:textarea codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
         </f:entry>
 
+        <j:if test="${it.views.size()>1}">
+          <f:entry title="${%Default View}" field="defaultView">
+            <select class="setting-input" name="primaryView">
+              <j:forEach var="v" items="${it.views}">
+                <j:choose>
+                  <j:when test="${it.primaryView==v}">
+                    <option value="${v.viewName}" selected="selected">${v.viewName}</option>
+                  </j:when>
+                  <j:otherwise>
+                    <option value="${v.viewName}">${v.viewName}</option>
+                  </j:otherwise>
+                </j:choose>
+              </j:forEach>
+            </select>
+          </f:entry>
+        </j:if>
+
         <!-- TODO tried to hide unless ${it.icon.descriptor.all().size() > 1} using f:invisibleEntry but this did not seem to work: -->
         <f:dropdownDescriptorSelector title="${%Icon}" field="icon"/>
 


### PR DESCRIPTION
This is PR #4 again without the extra commit, and without the `ModelObjectWithChildren` (will be a separate PR).

---
- Make the default view configurable (JENKINS-20235)
- Make the default default view an AllView (JENKINS-20006 -- it looks a bit weird, but that's because AllView looks weird in general)

Untested with real old 1.x data, but at least the test passes.

---

I did not implement the ListView-to-AllView conversion, as that can be added at any later time.
