### PR TITLE
Use transparent PNGs instead of GIFs

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/Folder/tasks-new.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/Folder/tasks-new.jelly
@@ -24,9 +24,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
 
-  <l:task icon="images/24x24/new-package.gif" href="${url}/new" title="${%newJob(it.newPronoun)}" permission="${it.CREATE}" />
+  <l:task icon="images/24x24/new-package.png" href="${url}/new" title="${%newJob(it.newPronoun)}" permission="${it.CREATE}" />
   <j:if test="${view==it.primaryView}">
     <!-- avoid showing two delete icons -->
-    <l:task icon="images/24x24/edit-delete.gif" href="${url}/delete" title="${%delete(it.pronoun)}" permission="${it.DELETE}" />
+    <l:task icon="images/24x24/edit-delete.png" href="${url}/delete" title="${%delete(it.pronoun)}" permission="${it.DELETE}" />
   </j:if>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/Folder/tasks-top.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/Folder/tasks-top.jelly
@@ -24,8 +24,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:this="this">
   <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
-  <l:task icon="images/24x24/up.gif" href="${url}/../../" title="${%Up}" contextMenu="false"/>
-  <l:task icon="images/24x24/search.gif"  href="${url}/" title="${%Status}" contextMenu="false" />
+  <l:task icon="images/24x24/up.png" href="${url}/../../" title="${%Up}" contextMenu="false"/>
+  <l:task icon="images/24x24/search.png"  href="${url}/" title="${%Status}" contextMenu="false" />
   <j:choose>
     <j:when test="${h.hasPermission(it,it.CONFIGURE)}">
       <l:task icon="images/24x24/setting.png" href="${url}/configure" title="${%Configure}" />


### PR DESCRIPTION
Some of the menu items are using the old gif versions of the icons with white backgrounds.  This PR simply updates them to use the newer (as of 3 years ago) PNG versions of the icons with transparent backgrounds.
