### PR TITLE
[JENKINS-27735] Disabling a folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ dist/
 nbdist/
 nbactions.xml
 nb-configuration.xml
+
+# Jenv
+.java-version
+

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
@@ -918,6 +918,14 @@ public class Folder extends AbstractItem
         items.remove(item.getName());
     }
 
+    @Exported
+    public boolean isDisabled() {
+        for (Job job : getAllJobs()) {
+            if (job.isBuildable()) return false;
+        }
+        return true;
+    }
+
     @Extension
     public static class DescriptorImpl extends TopLevelItemDescriptor {
         @Override

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/buildable/DisableAction.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/buildable/DisableAction.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 CloudBees.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.hudson.plugins.folder.buildable;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.Messages;
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Job;
+import jenkins.model.TransientActionFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+public class DisableAction implements Action {
+    private final Folder item;
+
+    public DisableAction(Folder folder) {
+        this.item = folder;
+    }
+
+    public String getIconFileName() {
+        if (!item.hasPermission(Job.CONFIGURE)) {
+            return null;
+        }
+        return "disabled.png";
+    }
+
+    public String getDisplayName() {
+        return Messages.DisableAction_displayName();
+    }
+
+    public String getUrlName() {
+        return "disable";
+    }
+
+    public Folder getItem() {
+        return item;
+    }
+
+    @Extension
+    public static class TransientActionFactoryImpl extends TransientActionFactory<Folder> {
+        @Override
+        public Class<Folder> type() {
+            return Folder.class;
+        }
+
+        @Override
+        public Collection<? extends Action> createFor(Folder target) {
+            return Collections.singleton(new DisableAction(target));
+        }
+    }
+
+    private static Logger LOGGER = Logger.getLogger(DisableAction.class.getName());
+}

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/buildable/DisableAction.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/buildable/DisableAction.java
@@ -43,7 +43,7 @@ public class DisableAction implements Action {
     }
 
     public String getIconFileName() {
-        if (!item.hasPermission(Job.CONFIGURE)) {
+        if (!item.hasPermission(Job.CONFIGURE) || item.isDisabled()) {
             return null;
         }
         return "disabled.png";

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/Messages.properties
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/Messages.properties
@@ -2,3 +2,4 @@ Folder.DisplayName=Folder
 Folder.DefaultPronoun=Item
 RelocateAction.permission.desc=Required to move a job from one folder (or Jenkins root) to another.
 RelocateAction.displayName=Move
+DisableAction.displayName=Disable

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/error.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/error.jelly
@@ -1,0 +1,19 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <l:layout title="${%Disable.title(it.item.getDisplayName())}">
+    <st:include page="sidepanel.jelly" it="${it.item}"/>
+    <l:main-panel>
+      <h1>
+        ${%Disable.title(it.item.getDisplayName())}
+      </h1>
+
+      ${%errorMessage}
+      <ul>
+        <j:forEach var="it" items="${missed}">
+          <li>${it.getFullDisplayName()}</li>
+        </j:forEach>
+      </ul>
+
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/error.properties
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/error.properties
@@ -1,0 +1,2 @@
+Disable.title=Disabling {0}
+errorMessage=We were not able to disable the following jobs:

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/index.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/index.jelly
@@ -6,6 +6,17 @@
       <h1>
         ${%Disable.title(it.item.getDisplayName())}
       </h1>
+
+      <form action="disable" method="POST">
+      ${%confirmationMessage}
+        <ul>
+          <j:forEach var="it" items="${it.getJobs()}">
+            <li>${it.getFullDisplayName()}</li>
+          </j:forEach>
+        </ul>
+
+        <f:submit value="${%Disable}"/>
+      </form>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/index.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/index.jelly
@@ -1,0 +1,11 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <l:layout title="${%Disable.title(it.item.getDisplayName())}">
+    <st:include page="sidepanel.jelly" it="${it.item}"/>
+    <l:main-panel>
+      <h1>
+        ${%Disable.title(it.item.getDisplayName())}
+      </h1>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/index.properties
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/index.properties
@@ -1,0 +1,2 @@
+Disable.title=Disabling {0}
+confirmationMessage=Are you sure you want to disable the following jobs?

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/index.properties
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/buildable/DisableAction/index.properties
@@ -1,2 +1,2 @@
-Disable.title=Disabling {0}
+Disable.title=Error disabling {0}
 confirmationMessage=Are you sure you want to disable the following jobs?


### PR DESCRIPTION
When folders are used to contain all jobs for a release or a feature, been able to disable all jobs in one click is a true time-saving feature.

Issue: [JENKINS-27735](https://issues.jenkins-ci.org/browse/JENKINS-27735)
