### PR TITLE
Allow configuration of view permissions in folders

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/AuthorizationMatrixProperty.java
@@ -36,6 +36,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.Run;
+import hudson.model.View;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
@@ -171,7 +172,7 @@ public class AuthorizationMatrixProperty extends FolderProperty<Folder> {
         }
 
         public List<PermissionGroup> getAllGroups() {
-            return Arrays.asList(PermissionGroup.get(Item.class),PermissionGroup.get(Run.class));
+            return Arrays.asList(PermissionGroup.get(Item.class),PermissionGroup.get(View.class),PermissionGroup.get(Run.class));
         }
 
         public boolean showPermission(Permission p) {


### PR DESCRIPTION
When configuring a folder, the view group of permissions will now be configurable.  You may now configure whether users can create/delete/configure or read views within a folder.

Maybe there is more work than I know of or some other constraints that are not taking into account as I'm not sure why this wasn't included to begin with.  Please let me know if so.