### PR TITLE
Add support for the `TopLevelItemDescriptor.isApplicableIn(ItemGroup)` method in 1.607+

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
@@ -806,7 +806,7 @@ public class Folder extends AbstractItem
         }
         // TODO Jenkins 1.607+ use method directly
         try {
-            return Boolean.TRUE.equals(tid.getClass().getMethod("isApplicableIn", ItemGroup.class).invoke(this));
+            return Boolean.TRUE.equals(tid.getClass().getMethod("isApplicableIn", ItemGroup.class).invoke(tid, this));
         } catch (NoSuchMethodException e) {
             // ignore
         } catch (InvocationTargetException e) {

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
@@ -69,6 +69,7 @@ import hudson.views.DefaultViewsTabBar;
 import hudson.views.ListViewColumn;
 import hudson.views.ViewJobFilter;
 import hudson.views.ViewsTabBar;
+import java.lang.reflect.InvocationTargetException;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.HttpResponse;
@@ -802,6 +803,16 @@ public class Folder extends AbstractItem
             if (!p.allowsParentToCreate(tid)) {
                 return false;
             }
+        }
+        // TODO Jenkins 1.607+ use method directly
+        try {
+            return Boolean.TRUE.equals(tid.getClass().getMethod("isApplicableIn", ItemGroup.class).invoke(this));
+        } catch (NoSuchMethodException e) {
+            // ignore
+        } catch (InvocationTargetException e) {
+            // ignore
+        } catch (IllegalAccessException e) {
+            // ignore
         }
         return true;
     }


### PR DESCRIPTION
Don't want to bump the core version of Jenkins just yet, so using reflection for now.
The use of reflection should not be a performance risk as the New Item page is not rendered
heavily, and in any case reflection gets inlined well by the JVM

@reviewbybees 