### PR TITLE
Fix typo

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -729,7 +729,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
 
         String blocker = renameBlocker();
         if (blocker != null) {
-            rsp.sendRedirect("rename?newName=" + URLEncoder.encode(newName, "UTF-8") + "&blocker=" + URLEncoder.encode(blocker, "UT-8"));
+            rsp.sendRedirect("rename?newName=" + URLEncoder.encode(newName, "UTF-8") + "&blocker=" + URLEncoder.encode(blocker, "UTF-8"));
             return;
         }
 


### PR DESCRIPTION
Received this error when renaming a multibranch workflow:

java.io.UnsupportedEncodingException: UT-8
	at java.net.URLEncoder.encode(URLEncoder.java:217)
	at com.cloudbees.hudson.plugins.folder.AbstractFolder.doDoRename(AbstractFolder.java:732)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

Fixed what looks like a typo.