### PR TITLE
[FIXED JENKINS-32309] - Allow Actions to contribute summary items for folders

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -91,6 +91,7 @@ import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ProjectNamingStrategy;
+import jenkins.model.TransientActionFactory;
 import net.sf.json.JSONObject;
 import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.context.SecurityContext;
@@ -110,6 +111,17 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 /**
  * A general-purpose {@link ItemGroup}.
  * Base for {@link Folder} and {@link ComputedFolder}.
+ * <p/>
+ * <b>Extending Folders UI</b><br/>
+ * As any other {@link Item} type, folder types support extension of UI via {@link Action}s.
+ * These actions can be persisted or added via {@link TransientActionFactory}.
+ * See <a href="https://wiki.jenkins-ci.org/display/JENKINS/Action+and+its+family+of+subtypes">this page</a> 
+ * for more details about actions.
+ * In folders actions provide the following features:
+ * <ul>
+ *  <li>Left sidepanel hyperlink, which opens the page specified by action's {@code index.jelly}.</li>
+ *  <li>Optional summary boxes on the main panel, which may be defined by {@code summary.jelly}.</li>
+ * </ul>
  * @since 4.11-beta-1
  */
 @SuppressWarnings({"unchecked", "rawtypes"}) // mistakes in various places

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
   </div>
   <!-- give actions a chance to contribute summary item -->
   <j:forEach var="a" items="${it.allActions}">
-    <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
+    <st:include page="summary" from="${a}" optional="true" it="${a}" />
   </j:forEach>
   <this:description />
 </j:jelly>

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
@@ -36,5 +36,9 @@ THE SOFTWARE.
       </div>
       <j:out value="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}"/>
   </div>
+  <!-- give actions a chance to contribute summary item -->
+  <j:forEach var="a" items="${it.allActions}">
+    <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
+  </j:forEach>
   <this:description />
 </j:jelly>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-32309
It's required for https://github.com/jenkinsci/ownership-plugin/pull/44

@reviewbybees 