### PR TITLE
Credentials dependency fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.8.3</version>
+      <version>1.18</version>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
@@ -415,7 +415,7 @@ public class FolderCredentialsProvider extends CredentialsProvider {
         }
 
         @SuppressWarnings({"unchecked", "rawtypes"}) // erasure
-        @Extension
+        @Extension(optional = true)
         public static class ActionFactory extends TransientActionFactory<AbstractFolder> {
             @Override
             public Class<AbstractFolder> type() {
@@ -439,7 +439,7 @@ public class FolderCredentialsProvider extends CredentialsProvider {
 
         }
 
-        @Extension
+        @Extension(optional = true)
         public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
 
             @Override


### PR DESCRIPTION
Without this you get a long ugly stack trace during startup if `credentials` is disabled. With the fix you get just

```
… hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1 error
WARNING: Failed to instantiate optional component com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider$FolderCredentialsProperty$DescriptorImpl; skipping
```

@reviewbybees esp. @daniel-beck