### PR TITLE
Allow Delete Folder to appear in context menu

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/sidepanel.jelly
@@ -22,4 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<st:include it="${it.primaryView}" page="sidepanel.jelly" xmlns:st="jelly:stapler"/>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    <j:if test="${view == null}"> <!-- true when rendering from ModelObjectWithContextMenu.ContextMenu.from -->
+        <j:set var="view" value="${it.primaryView}"/>
+    </j:if>
+    <st:include it="${it.primaryView}" page="sidepanel.jelly"/>
+</j:jelly>


### PR DESCRIPTION
So long as [JENKINS-32585](https://issues.jenkins-ci.org/browse/JENKINS-32585) is not implemented, a link in the sidepanel ought to be in the context menu unless we have explicitly specified `contextMenu=false`, which in this case we have not. (Anyway I find it quite convenient to use the context menu to blow away unwanted folders!)

The problem was that [here](https://github.com/jenkinsci/cloudbees-folder-plugin/blob/cd19df8330048af010056ce9c5d0920516632c4b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/tasks-new.jelly#L29) `view` was undefined.

@reviewbybees