### PR TITLE
[JENKINS-33479] [JENKINS-33480] Avoid calling `save` from within our own constructor

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -230,7 +230,6 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
     protected void initViews(List<View> views) throws IOException {
         AllView v = new AllView("All", this);
         views.add(v);
-        v.save();
     }
 
     @Override


### PR DESCRIPTION
Provides an alternative fix to #39 & https://github.com/jenkinsci/github-organization-folder-plugin/pull/2 (confirmed by temporarily reverting them and creating a GitHub organization), though it cannot hurt to keep those.

I considered making the override in `Folder` do the same, but [these lines](https://github.com/jenkinsci/cloudbees-folder-plugin/blob/2be74ab50054e110cae7dc158d7d18e8f04e1fa2/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java#L134-L135) would have saved the folder anyway, unless the `owner` were not passed to the `ListView` constructor—and it cannot be passed in afterwards. Those two lines also make it hard to remove the `throws IOException` clause, though that at least could be worked around. (And it would [not be binary incompatible](https://docs.oracle.com/javase/specs/jls/se7/html/jls-13.html#jls-13.4.21) for the [known overrider](https://github.com/jenkinsci/multi-branch-project-plugin/blob/d57f77f429a80b3496f218f5f7f941ab251f7812/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java#L190).) Anyway that override is only active in the rare case of a very old folder being migrated.

I also noticed that `save` is called several times immediately _after_ the folder is constructed, but this seems unavoidable due to calls [here](https://github.com/jenkinsci/github-organization-folder-plugin/blob/de7d12651404ce1267b93033c032b6f21199b9ca/src/main/java/org/jenkinsci/plugins/orgfolder/github/MainLogic.java#L108), [here](https://github.com/jenkinsci/branch-api-plugin/blob/feae9aa02470c500098fa29bfefc4652c0bf8ceb/src/main/java/jenkins/branch/CustomOrganizationFolderDescriptor.java#L76), [here](https://github.com/jenkinsci/branch-api-plugin/blob/feae9aa02470c500098fa29bfefc4652c0bf8ceb/src/main/java/jenkins/branch/OrganizationFolder.java#L84), [here](https://github.com/jenkinsci/branch-api-plugin/blob/feae9aa02470c500098fa29bfefc4652c0bf8ceb/src/main/java/jenkins/branch/OrganizationFolder.java#L88), and most importantly [here](https://github.com/jenkinsci/jenkins/blob/a57afbd1bc3fdeb47243696174d4b564ab50414f/core/src/main/java/hudson/model/ItemGroupMixIn.java#L321). These calls could probably be coalesced into one using a set of `BulkChange`s: one started in the `Folder`/`ComputedFolder` constructor, around `init`; one started in `CustomOrganizationFolderDescriptor.newInstance`; and one started in `createProject` after `newInstance` is called and finished after `fireOnCreated`. Very awkward, though: `BulkChange` provides no way of suppressing saves until after the object is constructed.

@reviewbybees esp. @kohsuke