### PR TITLE
[JENKINS-33006] Hour-based increments were not being round-tripped correctly

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
@@ -151,7 +151,7 @@ public class PeriodicFolderTrigger extends Trigger<ComputedFolder<?>> {
             return Long.toString(TimeUnit2.MILLISECONDS.toMinutes(interval)) + "m";
         }
         if (interval < TimeUnit2.DAYS.toMillis(1)) {
-            return Long.toString(TimeUnit2.MILLISECONDS.toHours(interval)) + "m";
+            return Long.toString(TimeUnit2.MILLISECONDS.toHours(interval)) + "h";
         }
         return Long.toString(TimeUnit2.MILLISECONDS.toDays(interval)) + "d";
     }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTriggerTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTriggerTest.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.hudson.plugins.folder.computed;
+
+import hudson.util.ListBoxModel;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.jvnet.hudson.test.Issue;
+
+public class PeriodicFolderTriggerTest {
+
+    @Issue("JENKINS-33006")
+    @Test
+    public void interval() throws Exception {
+        for (ListBoxModel.Option option : new PeriodicFolderTrigger.DescriptorImpl().doFillIntervalItems()) {
+            assertEquals("correctly round-trip " + option.name, option.value, new PeriodicFolderTrigger(option.value).getInterval());
+        }
+    }
+
+}


### PR DESCRIPTION
[JENKINS-33006](https://issues.jenkins-ci.org/browse/JENKINS-33006) seems to [always have been broken](https://github.com/jenkinsci/branch-api-plugin/commit/5e85b537e1ca543191967097fc25f00626f1e170#diff-33d257ebbba001788243c54bb248b1f6R155).

@reviewbybees esp. @stephenc