### PR TITLE
Expect FolderAddFilter to be called from View.doCategories

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/FolderAddFilter.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/FolderAddFilter.java
@@ -40,7 +40,8 @@ import org.kohsuke.stapler.StaplerRequest;
 
     @Override public boolean filter(Object context, Descriptor descriptor) {
         StaplerRequest req = Stapler.getCurrentRequest();
-        if (req == null || !req.getRequestURI().endsWith("/newJob")) {
+        // View/newJob.jelly for 1.x, View.doCategories for 2.x
+        if (req == null || !req.getRequestURI().matches(".*/(newJob|categories)")) {
             return true;
         }
         if (!(descriptor instanceof TopLevelItemDescriptor)) {


### PR DESCRIPTION
Fixes a bug identified in https://github.com/jenkinsci/jenkins/pull/2191.

Merely skipping the URI check, and applying the filtering unconditionally given a folder context, would seem simpler, but this would break code which is not part of _New Item_. For example, `SubItemFilterProperty` in `cloudbees-folders-plus` has a configuration fragment which lets you select item types to filter out. If `FolderAddFilter` were applied in `/job/folder/configure`, once you limited the folder to one item type, you would not be able to undo your decision, because the others would no longer be shown!

Tested using `SubItemFilterProperty` against both Jenkins 1.x and 2.x.

@reviewbybees esp. @recena