### PR TITLE
[JENKINS-33972] View.doCategories was renamed to View.doItemCategories

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/FolderAddFilter.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/FolderAddFilter.java
@@ -40,8 +40,8 @@ import org.kohsuke.stapler.StaplerRequest;
 
     @Override public boolean filter(Object context, Descriptor descriptor) {
         StaplerRequest req = Stapler.getCurrentRequest();
-        // View/newJob.jelly for 1.x, View.doCategories for 2.x
-        if (req == null || !req.getRequestURI().matches(".*/(newJob|categories)")) {
+        // View/newJob.jelly for 1.x, View.doItemCategories for 2.x
+        if (req == null || !req.getRequestURI().matches(".*/(newJob|itemCategories)")) {
             return true;
         }
         if (!(descriptor instanceof TopLevelItemDescriptor)) {


### PR DESCRIPTION
[JENKINS-33972](https://issues.jenkins-ci.org/browse/JENKINS-33972)

downstream of https://github.com/jenkinsci/jenkins/pull/2208

@reviewbybees especially @jglick and @oleg-nenashev 