### PR TITLE
[FIXED JENKINS-34306] When moving an item several destinations showed in the GUI are not valid

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
@@ -86,31 +86,34 @@ import org.kohsuke.stapler.HttpResponses;
                     continue;
                 }
                 ItemGroup<?> p = itemGroup;
-                Item i = (Item) p;
-                if (i == item || i == item.getParent()) {
-                    // Cannot move a folder into itself or a descendant.
-                    // Cannot move an item into the same path where it is
-                    continue ITEM;
-                }
-                if (i instanceof Folder) {
-                    Folder folder = (Folder) i;
-                    if (folder.getItem(item.getName()) != null) {
-                        // Cannot move an item into a Folder if there is already an item with the same name
+
+                if (p instanceof Item) {
+                    Item i = (Item) p;
+                    if (i == item || i == item.getParent()) {
+                        // Cannot move a folder into itself or a descendant.
+                        // Cannot move an item into the same path where it is
                         continue ITEM;
                     }
-                }
-                // Cannot move d1/ into say d1/d2/d3/
-                ItemGroup itemGroupSubElement = i.getParent();
-                while (itemGroupSubElement != instance) {
-                    if (itemGroupSubElement instanceof Folder) {
-                        Folder currentFolder = (Folder)itemGroupSubElement;
-                        if (item == currentFolder) {
+                    if (i instanceof Folder) {
+                        Folder folder = (Folder) i;
+                        if (folder.getItem(item.getName()) != null) {
+                            // Cannot move an item into a Folder if there is already an item with the same name
                             continue ITEM;
                         }
-                        itemGroupSubElement = currentFolder.getParent();
                     }
+                    // Cannot move d1/ into say d1/d2/d3/
+                    ItemGroup itemGroupSubElement = i.getParent();
+                    while (itemGroupSubElement != instance) {
+                        if (itemGroupSubElement instanceof Folder) {
+                            Folder currentFolder = (Folder) itemGroupSubElement;
+                            if (item == currentFolder) {
+                                continue ITEM;
+                            }
+                            itemGroupSubElement = currentFolder.getParent();
+                        }
+                    }
+                    result.add(itemGroup);
                 }
-                result.add(itemGroup);
             }
         }
         return result;

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
@@ -76,7 +76,10 @@ import org.kohsuke.stapler.HttpResponses;
     @Override public List<? extends ItemGroup<?>> validDestinations(Item item) {
         List<DirectlyModifiableTopLevelItemGroup> result = new ArrayList<DirectlyModifiableTopLevelItemGroup>();
         Jenkins instance = Jenkins.getActiveInstance();
-        if (permitted(item, instance) && instance.getItem(item.getName()) == null) {
+        // ROOT context is only added in case there is not any item with the same name
+        // But we add it in case the one is there is the item itself and not a different job with the same name
+        // No-op by default
+        if (permitted(item, instance) && (instance.getItem(item.getName()) == null) || instance.getItem(item.getName())==item) {
             result.add(instance);
         }
         ITEM: for (Item g : instance.getAllItems()) {
@@ -89,18 +92,22 @@ import org.kohsuke.stapler.HttpResponses;
 
                 if (p instanceof Item) {
                     Item i = (Item) p;
-                    if (i == item || i == item.getParent()) {
-                        // Cannot move a folder into itself or a descendant.
-                        // Cannot move an item into the same path where it is
+                    // Cannot move a folder into itself or a descendant
+                    if (i == item) {
                         continue ITEM;
                     }
+                    // By default the move is a no-op in case you hit it by mistake
+                    if (item.getParent() == i) {
+                        result.add(itemGroup);
+                    }
+                    // Cannot move an item into a Folder if there is already an item with the same name
                     if (i instanceof Folder) {
                         Folder folder = (Folder) i;
                         if (folder.getItem(item.getName()) != null) {
-                            // Cannot move an item into a Folder if there is already an item with the same name
                             continue ITEM;
                         }
                     }
+                    // Cannot move a folder into a descendant
                     // Cannot move d1/ into say d1/d2/d3/
                     ItemGroup itemGroupSubElement = i.getParent();
                     while (itemGroupSubElement != instance) {

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
@@ -79,7 +79,7 @@ import org.kohsuke.stapler.HttpResponses;
         // ROOT context is only added in case there is not any item with the same name
         // But we add it in case the one is there is the item itself and not a different job with the same name
         // No-op by default
-        if (permitted(item, instance) && (instance.getItem(item.getName()) == null) || instance.getItem(item.getName())==item) {
+        if (permitted(item, instance) && (instance.getItem(item.getName()) == null) || instance.getItem(item.getName()) == item) {
             result.add(instance);
         }
         ITEM: for (Item g : instance.getAllItems()) {

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
@@ -86,21 +86,18 @@ import org.kohsuke.stapler.HttpResponses;
                     continue;
                 }
                 ItemGroup<?> p = itemGroup;
-                while (p instanceof Item) {
-                    Item i = (Item) p;
-                    if (i == item || i == item.getParent()) {
-                        // Cannot move a folder into itself or a descendant.
-                        // Cannot move an item into the same path where it is
+                Item i = (Item) p;
+                if (i == item || i == item.getParent()) {
+                    // Cannot move a folder into itself or a descendant.
+                    // Cannot move an item into the same path where it is
+                    continue ITEM;
+                }
+                if (i instanceof Folder) {
+                    Folder folder = (Folder) i;
+                    if (folder.getItem(item.getName()) != null) {
+                        // Cannot move an item into a Folder if there is already an item with the same name
                         continue ITEM;
                     }
-                    if (i instanceof Folder) {
-                        Folder folder = (Folder) i;
-                        if (folder.getItem(item.getName()) != null) {
-                            // Cannot move an item into a Folder if there is already an item with the same name
-                            continue ITEM;
-                        }
-                    }
-                    p = i.getParent();
                 }
                 result.add(itemGroup);
             }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
@@ -24,6 +24,7 @@
 
 package com.cloudbees.hudson.plugins.folder.relocate;
 
+import com.cloudbees.hudson.plugins.folder.Folder;
 import hudson.Extension;
 import hudson.model.AbstractItem;
 import hudson.model.Item;
@@ -87,9 +88,17 @@ import org.kohsuke.stapler.HttpResponses;
                 ItemGroup<?> p = itemGroup;
                 while (p instanceof Item) {
                     Item i = (Item) p;
-                    if (i == item) {
+                    if (i == item || i == item.getParent()) {
                         // Cannot move a folder into itself or a descendant.
+                        // Cannot move an item into the same path where it is
                         continue ITEM;
+                    }
+                    if (i instanceof Folder) {
+                        Folder folder = (Folder) i;
+                        if (folder.getItem(item.getName()) != null) {
+                            // Cannot move an item into a Folder if there is already an item with the same name
+                            continue ITEM;
+                        }
                     }
                     p = i.getParent();
                 }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
@@ -51,7 +51,7 @@ import org.kohsuke.stapler.HttpResponses;
 @Extension(ordinal=-1000) public final class StandardHandler extends RelocationHandler {
 
     public HandlingMode applicability(Item item) {
-        if (item instanceof TopLevelItem && item instanceof AbstractItem && item.getParent() instanceof DirectlyModifiableTopLevelItemGroup) {
+        if (item instanceof TopLevelItem && item instanceof AbstractItem && item.getParent() instanceof DirectlyModifiableTopLevelItemGroup && !validDestinations(item).isEmpty()) {
             return HandlingMode.HANDLE;
         } else {
             return HandlingMode.SKIP;

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
@@ -89,7 +89,6 @@ import org.kohsuke.stapler.HttpResponses;
                     continue;
                 }
                 ItemGroup<?> p = itemGroup;
-
                 if (p instanceof Item) {
                     Item i = (Item) p;
                     // Cannot move a folder into itself or a descendant

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandler.java
@@ -76,7 +76,7 @@ import org.kohsuke.stapler.HttpResponses;
     @Override public List<? extends ItemGroup<?>> validDestinations(Item item) {
         List<DirectlyModifiableTopLevelItemGroup> result = new ArrayList<DirectlyModifiableTopLevelItemGroup>();
         Jenkins instance = Jenkins.getActiveInstance();
-        if (permitted(item, instance)) {
+        if (permitted(item, instance) && instance.getItem(item.getName()) == null) {
             result.add(instance);
         }
         ITEM: for (Item g : instance.getAllItems()) {
@@ -97,6 +97,17 @@ import org.kohsuke.stapler.HttpResponses;
                     if (folder.getItem(item.getName()) != null) {
                         // Cannot move an item into a Folder if there is already an item with the same name
                         continue ITEM;
+                    }
+                }
+                // Cannot move d1/ into say d1/d2/d3/
+                ItemGroup itemGroupSubElement = i.getParent();
+                while (itemGroupSubElement != instance) {
+                    if (itemGroupSubElement instanceof Folder) {
+                        Folder currentFolder = (Folder)itemGroupSubElement;
+                        if (item == currentFolder) {
+                            continue ITEM;
+                        }
+                        itemGroupSubElement = currentFolder.getParent();
                     }
                 }
                 result.add(itemGroup);

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandlerTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandlerTest.java
@@ -61,4 +61,28 @@ public class StandardHandlerTest {
         }
     }
 
+    @Test public void getDestinationsWithSubfolders() throws Exception {
+        Folder d1 = r.jenkins.createProject(Folder.class, "d1"); // where we start
+        Folder d11 = d1.createProject(Folder.class, "d11"); // where we could go
+        FreeStyleProject j = d1.createProject(FreeStyleProject.class, "j");
+        Folder d2 = r.jenkins.createProject(Folder.class, "d2"); // where we could go
+        Folder d3 = r.jenkins.createProject(Folder.class, "d3"); // where we could go
+        Folder d31 = d3.createProject(Folder.class, "d31"); // where we could go
+
+        assertEquals(Arrays.asList(r.jenkins, d11, d2, d3, d31), new StandardHandler().validDestinations(j));
+    }
+
+    @Test public void getDestinationsWithJobsWithSameName() throws Exception {
+        Folder d1 = r.jenkins.createProject(Folder.class, "d1"); // where we start
+        Folder d11 = d1.createProject(Folder.class, "d11"); // where we could go
+        FreeStyleProject j = d1.createProject(FreeStyleProject.class, "j");
+        Folder d2 = r.jenkins.createProject(Folder.class, "d2"); // where we could go
+        FreeStyleProject g = d2.createProject(FreeStyleProject.class, "j");
+        Folder d3 = r.jenkins.createProject(Folder.class, "d3"); // where we cannot
+        Folder d31 = d3.createProject(Folder.class, "d31"); // where we cannot
+
+
+        assertEquals(Arrays.asList(r.jenkins, d11, d3, d31), new StandardHandler().validDestinations(j));
+    }
+
 }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandlerTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandlerTest.java
@@ -54,7 +54,7 @@ public class StandardHandlerTest {
             grant(Item.CREATE).onItems(d2).to("joe"));
         SecurityContext sc = ACL.impersonate(User.get("joe").impersonate());
         try {
-            assertEquals(Arrays.asList(/* only because we are already here */d1, d2), new StandardHandler().validDestinations(j));
+            assertEquals(Arrays.asList(d2), new StandardHandler().validDestinations(j));
             assertEquals(Arrays.asList(/* ditto */r.jenkins, d2), new StandardHandler().validDestinations(d1));
         } finally {
             SecurityContextHolder.setContext(sc);

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandlerTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/relocate/StandardHandlerTest.java
@@ -54,11 +54,11 @@ public class StandardHandlerTest {
             grant(Item.CREATE).onItems(d2).to("joe"));
         SecurityContext sc = ACL.impersonate(User.get("joe").impersonate());
         try {
-            assertEquals(Arrays.asList(d2), new StandardHandler().validDestinations(j));
-            assertEquals(Arrays.asList(d2), new StandardHandler().validDestinations(d1));
+            assertEquals(Arrays.asList(d1, d2), new StandardHandler().validDestinations(j));
+            assertEquals(Arrays.asList(r.jenkins, d2), new StandardHandler().validDestinations(d1));
 
-            assertNotEquals(Arrays.asList(r.jenkins, j, d1, d3), new StandardHandler().validDestinations(j));
-            assertNotEquals(Arrays.asList(r.jenkins, j, d1, d3), new StandardHandler().validDestinations(d1));
+            assertNotEquals(Arrays.asList(r.jenkins, d3), new StandardHandler().validDestinations(j));
+            assertNotEquals(Arrays.asList(d1, d3), new StandardHandler().validDestinations(d1));
         } finally {
             SecurityContextHolder.setContext(sc);
         }
@@ -72,11 +72,10 @@ public class StandardHandlerTest {
         Folder d3 = r.jenkins.createProject(Folder.class, "d3");
         Folder d31 = d3.createProject(Folder.class, "d31");
 
-        assertEquals(Arrays.asList(r.jenkins, d11, d2, d3, d31), new StandardHandler().validDestinations(j));
-        assertEquals(Arrays.asList(r.jenkins, d2, d3, d31), new StandardHandler().validDestinations(d11));
+        assertEquals(Arrays.asList(r.jenkins, d1, d11, d2, d3, d31), new StandardHandler().validDestinations(j));
+        assertEquals(Arrays.asList(r.jenkins, d1, d2, d3, d31), new StandardHandler().validDestinations(d11));
 
-        assertNotEquals(d1, new StandardHandler().validDestinations(j));
-        assertNotEquals(Arrays.asList(d1, d11), new StandardHandler().validDestinations(d11));
+        assertNotEquals(d11, new StandardHandler().validDestinations(d11));
     }
 
     @Test public void getDestinationsUsingItemsWithSameName() throws Exception {
@@ -88,11 +87,11 @@ public class StandardHandlerTest {
         Folder d3 = r.jenkins.createProject(Folder.class, "d3");
         Folder d31 = d3.createProject(Folder.class, "d11");
 
-        assertEquals(Arrays.asList(r.jenkins, d11, d3, d31), new StandardHandler().validDestinations(j));
-        assertEquals(Arrays.asList(r.jenkins, d2, d31), new StandardHandler().validDestinations(d11));
+        assertEquals(Arrays.asList(r.jenkins, d1, d11, d3, d31), new StandardHandler().validDestinations(j));
+        assertEquals(Arrays.asList(r.jenkins, d1, d2, d31), new StandardHandler().validDestinations(d11));
 
-        assertNotEquals(Arrays.asList(d1, d2), new StandardHandler().validDestinations(j));
-        assertNotEquals(Arrays.asList(d1, d11, j, g, d3), new StandardHandler().validDestinations(d11));
+        assertNotEquals(d2, new StandardHandler().validDestinations(j));
+        assertNotEquals(Arrays.asList(d11, d3), new StandardHandler().validDestinations(d11));
     }
 
     @Test public void getDestinationsUsingItemsWithSameNameOnRootContext() throws Exception {
@@ -104,11 +103,11 @@ public class StandardHandlerTest {
         Folder d3 = r.jenkins.createProject(Folder.class, "d3");
         Folder d31 = d3.createProject(Folder.class, "d11");
 
-        assertEquals(Arrays.asList(d1, d11, d3, d31), new StandardHandler().validDestinations(j));
-        assertEquals(Arrays.asList(r.jenkins, d2, d31), new StandardHandler().validDestinations(d11));
+        assertEquals(Arrays.asList(r.jenkins, d1, d11, d3, d31), new StandardHandler().validDestinations(j));
+        assertEquals(Arrays.asList(r.jenkins, d1, d2, d31), new StandardHandler().validDestinations(d11));
 
-        assertNotEquals(Arrays.asList(g, j, r.jenkins, d2), new StandardHandler().validDestinations(j));
-        assertNotEquals(Arrays.asList(g, j, d1, d3), new StandardHandler().validDestinations(d11));
+        assertNotEquals(d2, new StandardHandler().validDestinations(j));
+        assertNotEquals(d3, new StandardHandler().validDestinations(d11));
     }
 
     @Test public void getDestinationsMovingAParentFolderInToTheTree() throws Exception {
@@ -117,8 +116,8 @@ public class StandardHandlerTest {
         Folder d12 = d11.createProject(Folder.class, "d3");
         Folder d4 = r.jenkins.createProject(Folder.class, "d4");
 
-        assertEquals(Arrays.asList(d4), new StandardHandler().validDestinations(d1));
-        assertNotEquals(Arrays.asList(r.jenkins, d1, d11, d12), new StandardHandler().validDestinations(d1));
+        assertEquals(Arrays.asList(r.jenkins, d4), new StandardHandler().validDestinations(d1));
+        assertNotEquals(Arrays.asList(d11, d12), new StandardHandler().validDestinations(d1));
     }
 
 }


### PR DESCRIPTION
1. create a job A in a folder A 
2. create a job with the same name A in another folder B 
3. Then, the move option tells you can move to:

```
Jenkins
Jenkins >> Folder A
Jenkins >> Folder B
````

But this is wrong because `Jenkins >> Folder A` is the item itself and in `Jenkins >> Folder B` there is already an item with the same name - we should cover these cases.

https://issues.jenkins-ci.org/browse/JENKINS-34306

@reviewbybees CC @jglick 