### PR TITLE
[JENKINS-33622] Get 2.x UI to show on config page

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -61,6 +61,7 @@ import hudson.util.FormApply;
 import hudson.util.FormValidation;
 import hudson.util.Function1;
 import hudson.util.HttpResponses;
+import hudson.util.VersionNumber;
 import hudson.views.DefaultViewsTabBar;
 import hudson.views.ViewsTabBar;
 import java.io.File;
@@ -123,6 +124,8 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractItem implements TopLevelItem, ItemGroup<I>, ModifiableViewGroup, StaplerFallback, ModelObjectWithChildren, StaplerOverridable {
 
     private static final Logger LOGGER = Logger.getLogger(AbstractFolder.class.getName());
+
+    private static final VersionNumber VERSION_TWO = new VersionNumber("2.0");
 
     private static long loadingTick;
     private static final AtomicInteger jobTotal = new AtomicInteger();
@@ -783,6 +786,10 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
             }
         }
         return null;
+    }
+
+    public static boolean useLegacyUi() {
+        return Jenkins.getVersion().isOlderThan(VERSION_TWO);
     }
 
 }

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -23,72 +23,30 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName} Config" norefresh="true" permission="${it.EXTENDED_READ}">
-    <st:include page="sidepanel.jelly" />
-    <l:main-panel>
-      <div class="behavior-loading">${%LOADING}</div>
-      <f:form method="post" action="configSubmit" name="config">
-        <j:set var="descriptor" value="${it.descriptor}" />
-        <j:set var="instance" value="${it}" />
-
-        <f:entry title="${%Name}" field="name">
-          <f:textbox />
-        </f:entry>
-
-        <f:entry title="${%Display Name}" field="displayNameOrNull">
-          <f:textbox checkUrl="'${rootURL}/checkDisplayName?displayName='+encodeURIComponent(this.value)+'&amp;jobName='+encodeURIComponent('${h.jsStringEscape(it.name)}')"/>
-        </f:entry>
-
-        <f:entry title="${%Description}" field="description">
-          <f:textarea codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
-        </f:entry>
-
-        <st:include page="configure-details" optional="true"/>
-
-        <j:if test="${it.views.size()>1}">
-          <f:entry title="${%Default View}" field="defaultView">
-            <select class="setting-input" name="primaryView">
-              <j:forEach var="v" items="${it.views}">
-                <j:choose>
-                  <j:when test="${it.primaryView==v}">
-                    <option value="${v.viewName}" selected="selected">${v.viewName}</option>
-                  </j:when>
-                  <j:otherwise>
-                    <option value="${v.viewName}">${v.viewName}</option>
-                  </j:otherwise>
-                </j:choose>
-              </j:forEach>
-            </select>
-          </f:entry>
-        </j:if>
-
-        <f:dropdownDescriptorSelector title="${%Views Tab Bar}" field="viewsTabBar"/>
-
-        <!-- TODO tried to hide unless ${it.icon.descriptor.all().size() > 1} using f:invisibleEntry but this did not seem to work: -->
-        <f:dropdownDescriptorSelector title="${%Icon}" field="icon"/>
-
-        <f:section title="${%Health metrics}">
-          <f:advanced title="${%Health metrics}" align="left">
-            <f:block>
-              <f:hetero-list descriptors="${descriptor.getHealthMetricDescriptors()}"
-                             items="${it.healthMetrics}" name="healthMetrics"
-                             addCaption="${%Add metric}" deleteCaption="${%Remove}"
-                             oneEach="true" hasHeader="true" honorOrder="true"/>
-            </f:block>
-          </f:advanced>
-        </f:section>
-
-        <!-- folder  property configurations -->
-        <f:descriptorList descriptors="${descriptor.getPropertyDescriptors()}" instances="${it.properties}" forceRowSet="true" />
-
-        <j:if test="${h.hasPermission(it,it.CONFIGURE)}">
-          <f:bottomButtonBar>
-               <f:submit value="${%Save}" />
-               <f:apply/>
-          </f:bottomButtonBar>
-        </j:if>
-      </f:form>
-      <st:adjunct includes="lib.form.confirm" />
-    </l:main-panel>
-  </l:layout>
+  <j:choose>
+    <!-- TODO Remove logic and bring configure2 back in when base is upgraded to 2.x. -->
+    <j:when test="${it.useLegacyUi()}">
+      <l:layout norefresh="true" permission="${it.EXTENDED_READ}" title="${it.displayName} Config">
+        <st:include page="sidepanel.jelly"/>
+        <l:main-panel>
+          <st:include page="configure2.jelly"/>
+        </l:main-panel>
+      </l:layout>
+    </j:when>
+    <j:otherwise>
+      <l:layout norefresh="true" type="one-column" permission="${it.EXTENDED_READ}" title="${it.displayName} Config">
+        <l:js src="jsbundles/config-scrollspy.js"/>
+        <l:css src="jsbundles/config-scrollspy.css"/>
+        <l:main-panel>
+          <div class="container">
+            <div class="row">
+              <div class="col-md-offset-2 col-md-20">
+                <st:include page="configure2.jelly"/>
+              </div>
+            </div>
+          </div>
+        </l:main-panel>
+      </l:layout>
+    </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure2.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure2.jelly
@@ -1,0 +1,102 @@
+<!--
+The MIT License
+
+Copyright 2013 CloudBees.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <div class="behavior-loading">${%LOADING}</div>
+    <f:form method="post" action="configSubmit" name="config" tableClass="config-table scrollspy">
+        <j:set var="descriptor" value="${it.descriptor}"/>
+        <j:set var="instance" value="${it}"/>
+
+        <f:entry title="${%Name}" field="name">
+            <!--
+              TODO Remove block-control class
+
+              Having this forces application of the 2.x UI but it is glitchy if no f:optionalBlock or f:radioBlock
+              elements are in the form (such is the case for the standard Folder implementation).
+
+              The save/apply buttons are out of place until the DOM is modified by expanding config elements or by
+              resizing the browser window.
+            -->
+            <f:textbox clazz="block-control"/>
+        </f:entry>
+
+        <f:entry title="${%Display Name}" field="displayNameOrNull">
+            <f:textbox
+                    checkUrl="'${rootURL}/checkDisplayName?displayName='+encodeURIComponent(this.value)+'&amp;jobName='+encodeURIComponent('${h.jsStringEscape(it.name)}')"/>
+        </f:entry>
+
+        <f:entry title="${%Description}" field="description">
+            <f:textarea codemirror-mode="${app.markupFormatter.codeMirrorMode}"
+                        codemirror-config="${app.markupFormatter.codeMirrorConfig}"
+                        previewEndpoint="/markupFormatter/previewDescription"/>
+        </f:entry>
+
+        <st:include page="configure-details" optional="true"/>
+
+        <j:if test="${it.views.size()>1}">
+            <f:entry title="${%Default View}" field="defaultView">
+                <select class="setting-input" name="primaryView">
+                    <j:forEach var="v" items="${it.views}">
+                        <j:choose>
+                            <j:when test="${it.primaryView==v}">
+                                <option value="${v.viewName}" selected="selected">${v.viewName}</option>
+                            </j:when>
+                            <j:otherwise>
+                                <option value="${v.viewName}">${v.viewName}</option>
+                            </j:otherwise>
+                        </j:choose>
+                    </j:forEach>
+                </select>
+            </f:entry>
+        </j:if>
+
+        <f:dropdownDescriptorSelector title="${%Views Tab Bar}" field="viewsTabBar"/>
+
+        <!-- TODO tried to hide unless ${it.icon.descriptor.all().size() > 1} using f:invisibleEntry but this did not seem to work: -->
+        <f:dropdownDescriptorSelector title="${%Icon}" field="icon"/>
+
+        <f:section title="${%Health metrics}">
+            <f:advanced title="${%Health metrics}" align="left">
+                <f:block>
+                    <f:hetero-list descriptors="${descriptor.getHealthMetricDescriptors()}"
+                                   items="${it.healthMetrics}" name="healthMetrics"
+                                   addCaption="${%Add metric}" deleteCaption="${%Remove}"
+                                   oneEach="true" hasHeader="true" honorOrder="true"/>
+                </f:block>
+            </f:advanced>
+        </f:section>
+
+        <!-- folder  property configurations -->
+        <f:descriptorList descriptors="${descriptor.getPropertyDescriptors()}" instances="${it.properties}"
+                          forceRowSet="true"/>
+
+        <j:if test="${h.hasPermission(it,it.CONFIGURE)}">
+            <f:bottomButtonBar>
+                <f:submit value="${%Save}"/>
+                <f:apply/>
+            </f:bottomButtonBar>
+        </j:if>
+    </f:form>
+    <st:adjunct includes="lib.form.confirm"/>
+</j:jelly>


### PR DESCRIPTION
DO NOT MERGE -- mostly for demonstration at the moment

Besides the nasty logic to detect version and display different views based on hardcoded `"2.0"`...

Looks good on `ComputedFolder` types since the Orphaned Item Strategy has `f:optionalBlock` or `f:radioBlock`.  Seemed to switch between 1.x UI and 2.x UI just fine based on Jenkins version in use.

More on that:

`config-scrollspy.js` only applies to the config if a form element has the `block-control` CSS class applied to it.

https://github.com/jenkinsci/jenkins/blob/jenkins-2.12/war/src/main/js/widgets/config/tabbar.js#L19

Only `f:optionalBlock` and `f:radioBlock` apply this class.

https://github.com/jenkinsci/jenkins/blob/jenkins-2.12/core/src/main/resources/lib/form/optionalBlock.jelly#L71
https://github.com/jenkinsci/jenkins/blob/jenkins-2.12/core/src/main/resources/lib/form/radioBlock.jelly#L61

The standard `Folder` contains none of those elements, so the new UI is not applied.  This PR forces application by adding that class to a field.  There may be other folder types with this problem (`ComputedFolder` is ok).

If forced to apply the new UI to a Folder, the save/apply buttons are out of place until the DOM is modified by expanding config elements or by resizing the browser window (shown below)

![image](https://cloud.githubusercontent.com/assets/817707/16756645/5eef3bae-47bb-11e6-8ad1-3ee83e54de6b.png)
