### PR TITLE
Fix javadoc errors

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -106,8 +106,8 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 /**
  * A general-purpose {@link ItemGroup}.
  * Base for {@link Folder} and {@link ComputedFolder}.
- * <p/>
- * <b>Extending Folders UI</b><br/>
+ * <p>
+ * <b>Extending Folders UI</b><br>
  * As any other {@link Item} type, folder types support extension of UI via {@link Action}s.
  * These actions can be persisted or added via {@link TransientActionFactory}.
  * See <a href="https://wiki.jenkins-ci.org/display/JENKINS/Action+and+its+family+of+subtypes">this page</a> 


### PR DESCRIPTION
Minor javadoc fixes. 

```
[ERROR] /Users/armando/Development/cloudbees-folder-plugin/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java:109: error: self-closing element not allowed
[ERROR] * <p/>
[ERROR] ^
[ERROR] /Users/armando/Development/cloudbees-folder-plugin/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java:110: error: self-closing element not allowed
[ERROR] * <b>Extending Folders UI</b><br/>
```

@reviewbybees 