### PR TITLE
Fix IDE warnings about unimplemented `onRenamed` and `onDeleted` methods

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -609,7 +609,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
     @Override
     public void onRenamed(I item, String oldName, String newName) throws IOException {
         items.remove(oldName);
-        items.put(newName, (I) item);
+        items.put(newName, item);
         // For compatibility with old views:
         for (View v : views) {
             v.onJobRenamed(item, oldName, newName);

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -607,7 +607,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
 
     @SuppressWarnings("deprecation")
     @Override
-    public void onRenamed(TopLevelItem item, String oldName, String newName) throws IOException {
+    public void onRenamed(I item, String oldName, String newName) throws IOException {
         items.remove(oldName);
         items.put(newName, (I) item);
         // For compatibility with old views:
@@ -619,7 +619,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
 
     @SuppressWarnings("deprecation")
     @Override
-    public void onDeleted(TopLevelItem item) throws IOException {
+    public void onDeleted(I item) throws IOException {
         ItemListener.fireOnDeleted(item);
         items.remove(item.getName());
         // For compatibility with old views:

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -629,18 +629,6 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         save();
     }
 
-    // Bridge method when accessed as {@link ItemGroup} with a raw type.
-    @SuppressWarnings("deprecation")
-    public void onRenamed(Item item, String oldName, String newName) throws IOException {
-        onRenamed((I)item, oldName, newName);
-    }
-
-    // Bridge method when accessed as {@link ItemGroup} with a raw type.
-    @SuppressWarnings("deprecation")
-    public void onDeleted(Item item) throws IOException {
-        onDeleted((I)item);
-    }
-
     @Override
     public void delete() throws IOException, InterruptedException {
         // Some parts copied from AbstractItem.

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -629,6 +629,18 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         save();
     }
 
+    // Bridge method when accessed as {@link ItemGroup} with a raw type.
+    @SuppressWarnings("deprecation")
+    public void onRenamed(Item item, String oldName, String newName) throws IOException {
+        onRenamed((I)item, oldName, newName);
+    }
+
+    // Bridge method when accessed as {@link ItemGroup} with a raw type.
+    @SuppressWarnings("deprecation")
+    public void onDeleted(Item item) throws IOException {
+        onDeleted((I)item);
+    }
+
     @Override
     public void delete() throws IOException, InterruptedException {
         // Some parts copied from AbstractItem.


### PR DESCRIPTION
- The type erasure means that the methods are the same

- The generated bytecode only assumes `TopLevelItem` as the class: 
```
public void onRenamed(I, java.lang.String, java.lang.String) throws java.io.IOException;
    Code:
       0: aload_0
       1: getfield      #24                 // Field items:Ljava/util/Map;
       4: aload_2
       5: invokeinterface #178,  2          // InterfaceMethod java/util/Map.remove:(Ljava/lang/Object;)Ljava/lang/Object;
      10: pop
      11: aload_0
      12: getfield      #24                 // Field items:Ljava/util/Map;
      15: aload_3
      16: aload_1
      17: invokeinterface #179,  3          // InterfaceMethod java/util/Map.put:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
      22: pop
      23: aload_0
      24: getfield      #6                  // Field views:Ljava/util/concurrent/CopyOnWriteArrayList;
      27: invokevirtual #180                // Method java/util/concurrent/CopyOnWriteArrayList.iterator:()Ljava/util/Iterator;
      30: astore        4
      32: aload         4
      34: invokeinterface #30,  1           // InterfaceMethod java/util/Iterator.hasNext:()Z
      39: ifeq          65
      42: aload         4
      44: invokeinterface #31,  1           // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
      49: checkcast     #124                // class hudson/model/View
      52: astore        5
      54: aload         5
      56: aload_1
      57: aload_2
      58: aload_3
      59: invokevirtual #181                // Method hudson/model/View.onJobRenamed:(Lhudson/model/Item;Ljava/lang/String;Ljava/lang/String;)V
      62: goto          32
      65: aload_0
      66: invokevirtual #182                // Method save:()V
      69: return

  public void onDeleted(I) throws java.io.IOException;
    Code:
       0: aload_1
       1: invokestatic  #183                // Method hudson/model/listeners/ItemListener.fireOnDeleted:(Lhudson/model/Item;)V
       4: aload_0
       5: getfield      #24                 // Field items:Ljava/util/Map;
       8: aload_1
       9: invokeinterface #96,  1           // InterfaceMethod hudson/model/TopLevelItem.getName:()Ljava/lang/String;
      14: invokeinterface #178,  2          // InterfaceMethod java/util/Map.remove:(Ljava/lang/Object;)Ljava/lang/Object;
      19: pop
      20: aload_0
      21: getfield      #6                  // Field views:Ljava/util/concurrent/CopyOnWriteArrayList;
      24: invokevirtual #180                // Method java/util/concurrent/CopyOnWriteArrayList.iterator:()Ljava/util/Iterator;
      27: astore_2
      28: aload_2
      29: invokeinterface #30,  1           // InterfaceMethod java/util/Iterator.hasNext:()Z
      34: ifeq          62
      37: aload_2
      38: invokeinterface #31,  1           // InterfaceMethod java/util/Iterator.next:()Ljava/lang/Object;
      43: checkcast     #124                // class hudson/model/View
      46: astore_3
      47: aload_3
      48: aload_1
      49: aload_1
      50: invokeinterface #96,  1           // InterfaceMethod hudson/model/TopLevelItem.getName:()Ljava/lang/String;
      55: aconst_null
      56: invokevirtual #181                // Method hudson/model/View.onJobRenamed:(Lhudson/model/Item;Ljava/lang/String;Ljava/lang/String;)V
      59: goto          28
      62: aload_0
      63: invokevirtual #182                // Method save:()V
      66: return
```

- We have synthetic `onDeleted(Item)` and `onRenamed(Item,String,String)` anyway (though unclear where they come from)
```
Compiled from "AbstractFolder.java"
public abstract class com.cloudbees.hudson.plugins.folder.AbstractFolder<I extends hudson.model.TopLevelItem> extends hudson.model.AbstractItem implements hudson.model.TopLevelItem, hudson.model.ItemGroup<I>, hudson.model.ModifiableViewGroup, org.kohsuke.stapler.StaplerFallback, jenkins.model.ModelObjectWithChildren, org.kohsuke.stapler.StaplerOverridable {
  protected transient java.util.Map<java.lang.String, I> items;
  public static void loadJobTotal();
  protected com.cloudbees.hudson.plugins.folder.AbstractFolder(hudson.model.ItemGroup, java.lang.String);
  protected void init();
  protected void initViews(java.util.List<hudson.model.View>) throws java.io.IOException;
  public void addAction(hudson.model.Action);
  public void replaceAction(hudson.model.Action);
  public void onLoad(hudson.model.ItemGroup<? extends hudson.model.Item>, java.lang.String) throws java.io.IOException;
  public com.cloudbees.hudson.plugins.folder.AbstractFolderDescriptor getDescriptor();
  public hudson.util.DescribableList<com.cloudbees.hudson.plugins.folder.AbstractFolderProperty<?>, com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor> getProperties();
  public void addProperty(com.cloudbees.hudson.plugins.folder.AbstractFolderProperty) throws java.io.IOException;
  protected java.io.File getJobsDir();
  protected final java.io.File getRootDirFor(java.lang.String);
  public java.io.File getRootDirFor(I);
  public java.lang.String getUrlChildPrefix();
  public I getJob(java.lang.String);
  public java.lang.String getPronoun();
  public java.util.Collection<?> getOverrides();
  public void addView(hudson.model.View) throws java.io.IOException;
  public boolean canDelete(hudson.model.View);
  public void deleteView(hudson.model.View) throws java.io.IOException;
  public hudson.model.View getView(java.lang.String);
  public java.util.Collection<hudson.model.View> getViews();
  public hudson.model.View getPrimaryView();
  public void setPrimaryView(hudson.model.View);
  public void onViewRenamed(hudson.model.View, java.lang.String, java.lang.String);
  public hudson.views.ViewsTabBar getViewsTabBar();
  public hudson.model.ItemGroup<? extends hudson.model.TopLevelItem> getItemGroup();
  public java.util.List<hudson.model.Action> getViewActions();
  public hudson.model.View getStaplerFallback();
  protected hudson.search.SearchIndexBuilder makeSearchIndex();
  public jenkins.model.ModelObjectWithContextMenu$ContextMenu doChildrenContextMenu(org.kohsuke.stapler.StaplerRequest, org.kohsuke.stapler.StaplerResponse);
  public synchronized void doCreateView(org.kohsuke.stapler.StaplerRequest, org.kohsuke.stapler.StaplerResponse) throws java.io.IOException, javax.servlet.ServletException, java.text.ParseException, hudson.model.Descriptor$FormException;
  public hudson.util.FormValidation doViewExistsCheck(java.lang.String);
  public hudson.model.HealthReport getBuildHealth();
  public java.util.List<hudson.model.HealthReport> getBuildHealthReports();
  public hudson.util.DescribableList<com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric, com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor> getHealthMetrics();
  public org.kohsuke.stapler.HttpResponse doLastBuild(org.kohsuke.stapler.StaplerRequest);
  public com.cloudbees.hudson.plugins.folder.FolderIcon getIcon();
  public void setIcon(com.cloudbees.hudson.plugins.folder.FolderIcon);
  public com.cloudbees.hudson.plugins.folder.FolderIcon getIconColor();
  public java.util.Collection<? extends hudson.model.Job> getAllJobs();
  public java.util.Collection<I> getItems();
  public I getItem(java.lang.String) throws org.acegisecurity.AccessDeniedException;
  public void onRenamed(I, java.lang.String, java.lang.String) throws java.io.IOException;
  public void onDeleted(I) throws java.io.IOException;
  public void delete() throws java.io.IOException, java.lang.InterruptedException;
  public synchronized void save() throws java.io.IOException;
  public void renameTo(java.lang.String) throws java.io.IOException;
  public synchronized void doSubmitDescription(org.kohsuke.stapler.StaplerRequest, org.kohsuke.stapler.StaplerResponse) throws java.io.IOException, javax.servlet.ServletException;
  public void doConfigSubmit(org.kohsuke.stapler.StaplerRequest, org.kohsuke.stapler.StaplerResponse) throws java.io.IOException, javax.servlet.ServletException, hudson.model.Descriptor$FormException;
  protected java.lang.String getSuccessfulDestination();
  protected void submit(org.kohsuke.stapler.StaplerRequest, org.kohsuke.stapler.StaplerResponse) throws java.io.IOException, javax.servlet.ServletException, hudson.model.Descriptor$FormException;
  public void doDoRename(org.kohsuke.stapler.StaplerRequest, org.kohsuke.stapler.StaplerResponse) throws java.io.IOException, javax.servlet.ServletException;
  protected java.lang.String renameBlocker();
  public hudson.model.TopLevelItemDescriptor getDescriptor();
  public hudson.model.Descriptor getDescriptor();
  public void onDeleted(hudson.model.Item) throws java.io.IOException;
  public void onRenamed(hudson.model.Item, java.lang.String, java.lang.String) throws java.io.IOException;
  public java.io.File getRootDirFor(hudson.model.Item);
  public hudson.model.Item getItem(java.lang.String) throws org.acegisecurity.AccessDeniedException;
  public java.lang.Object getStaplerFallback();
  static java.util.concurrent.CopyOnWriteArrayList access$000(com.cloudbees.hudson.plugins.folder.AbstractFolder);
  static java.lang.String access$100(com.cloudbees.hudson.plugins.folder.AbstractFolder);
  static java.lang.String access$102(com.cloudbees.hudson.plugins.folder.AbstractFolder, java.lang.String);
  static java.util.concurrent.atomic.AtomicInteger access$200();
  static java.util.concurrent.atomic.AtomicInteger access$300();
  static long access$400();
  static long access$402(long);
  static java.util.logging.Logger access$500();
  static {};
}
```

@reviewbybees