### PR TITLE
[JENKINS-41842] Increase test coverage for computed folder

### DIFF
--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -62,7 +62,6 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
@@ -153,6 +152,30 @@ public class ComputedFolderTest {
         a1.keepLog(false);
         d.recompute(Result.SUCCESS);
         d.assertItemNames(5);
+    }
+
+    @Test
+    public void notAddChildren() throws Exception {
+        JenkinsRule.WebClient client = r.createWebClient();
+        SampleComputedFolder s = r.jenkins.createProject(SampleComputedFolder.class, "s");
+
+        assertThat(client.getPage(s).getByXPath("//a[contains(text(), \"New Item\")]").size(), is(0));
+
+        s.kids.add("A");
+        s.recompute(Result.SUCCESS);
+
+        assertThat(client.getPage(s).getByXPath("//a[contains(text(), \"New Item\")]").size(), is(0));
+    }
+
+    @Test
+    public void runByTrigger() throws Exception {
+        SampleComputedFolder s = r.jenkins.createProject(SampleComputedFolder.class, "s");
+        s.assertItemNames(0);
+
+        s.addTrigger(new PeriodicFolderTrigger("1m"));
+
+        Thread.sleep(65000);
+        s.assertItemNames(1);
     }
 
     /** Verify that running branch projects are not deleted even after an organization folder reindex. */

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -159,12 +159,12 @@ public class ComputedFolderTest {
         JenkinsRule.WebClient client = r.createWebClient();
         SampleComputedFolder s = r.jenkins.createProject(SampleComputedFolder.class, "s");
 
-        assertThat(client.getPage(s).getByXPath("//a[contains(text(), \"New Item\")]").size(), is(0));
+        assertEquals(client.getPage(s).getByXPath("//a[contains(text(), \"New Item\")]").size(), 0);
 
         s.kids.add("A");
         s.recompute(Result.SUCCESS);
 
-        assertThat(client.getPage(s).getByXPath("//a[contains(text(), \"New Item\")]").size(), is(0));
+        assertEquals(client.getPage(s).getByXPath("//a[contains(text(), \"New Item\")]").size(), 0);
     }
 
     @Test
@@ -172,9 +172,12 @@ public class ComputedFolderTest {
         SampleComputedFolder s = r.jenkins.createProject(SampleComputedFolder.class, "s");
         s.assertItemNames(0);
 
-        s.addTrigger(new PeriodicFolderTrigger("1m"));
+        PeriodicFolderTrigger t = new PeriodicFolderTrigger("1m");
+        s.addTrigger(t);
+        t.run();
 
-        Thread.sleep(65000);
+        Thread.sleep(2000);
+
         s.assertItemNames(1);
     }
 

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -176,7 +176,7 @@ public class ComputedFolderTest {
         s.addTrigger(t);
         t.run();
 
-        Thread.sleep(2000);
+        r.waitUntilNoActivity();
 
         s.assertItemNames(1);
     }


### PR DESCRIPTION
[JENKINS-41842](https://issues.jenkins-ci.org/browse/JENKINS-41842)

Tests validating:
- No new item can be added manually to a computed folder.
- Trigger causes a computation.

@reviewbybees @stephenc 