### PR TITLE
[JENKINS-37369] Expose the last computation for computed folders

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -43,6 +43,7 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.ResourceList;
+import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
 import hudson.model.listeners.ItemListener;
@@ -592,6 +593,36 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
     @Nonnull
     public FolderComputation<I> getComputation() {
         return computation;
+    }
+
+    @Restricted(NoExternalUse.class) // used by stapler only
+    public PseudoRun<I> getLastSuccessfulBuild() {
+        FolderComputation<I> computation = getComputation();
+        Result result = computation.getResult();
+        if (result != null && Result.UNSTABLE.isWorseOrEqualTo(result)) {
+            return new PseudoRun(computation);
+        }
+        return null;
+    }
+
+    @Restricted(NoExternalUse.class) // used by stapler only
+    public PseudoRun<I> getLastStableBuild() {
+        FolderComputation<I> computation = getComputation();
+        Result result = computation.getResult();
+        if (result != null && Result.SUCCESS.isWorseOrEqualTo(result)) {
+            return new PseudoRun(computation);
+        }
+        return null;
+    }
+
+    @Restricted(NoExternalUse.class) // used by stapler only
+    public PseudoRun<I> getLastFailedBuild() {
+        FolderComputation<I> computation = getComputation();
+        Result result = computation.getResult();
+        if (result != null && Result.UNSTABLE.isBetterThan(result)) {
+            return new PseudoRun(computation);
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PseudoRun.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PseudoRun.java
@@ -108,15 +108,15 @@ public class PseudoRun<I extends TopLevelItem> extends Actionable implements Sta
     }
 
     public HttpResponse doIndex(StaplerRequest request) {
-        return HttpResponses.redirectTo(Jenkins.getActiveInstance().getRootUrlFromRequest() + computation.getUrl() );
+        return HttpResponses.redirectViaContextPath(computation.getUrl());
     }
 
     public HttpResponse doConsole(StaplerRequest request) {
-        return HttpResponses.redirectTo(Jenkins.getActiveInstance().getRootUrlFromRequest() + computation.getUrl() + "console");
+        return HttpResponses.redirectViaContextPath(computation.getUrl() + "console");
     }
 
     public HttpResponse doConsoleText(StaplerRequest request) {
-        return HttpResponses.redirectTo(Jenkins.getActiveInstance().getRootUrlFromRequest() + computation.getUrl() + "consoleText");
+        return HttpResponses.redirectViaContextPath(computation.getUrl() + "consoleText");
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PseudoRun.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PseudoRun.java
@@ -1,0 +1,151 @@
+package com.cloudbees.hudson.plugins.folder.computed;
+
+import hudson.Functions;
+import hudson.Util;
+import hudson.model.Actionable;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TopLevelItem;
+import java.io.File;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.StaplerFallback;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * A fake {@link Run} used to render last build information via Stapler and Jelly
+ */
+@Restricted(NoExternalUse.class) // used by stapler / jelly only
+public class PseudoRun<I extends TopLevelItem> extends Actionable implements StaplerFallback {
+    private final FolderComputation<I> computation;
+
+    PseudoRun(FolderComputation<I> computation) {
+        this.computation = computation;
+    }
+
+    public String getDisplayName() {
+        return "log";
+    }
+
+    public RunUrl decompose(StaplerRequest req) {
+        List<Ancestor> ancestors = req.getAncestors();
+
+        // find the first and last Run instances
+        Ancestor f = null, l = null;
+        for (Ancestor anc : ancestors) {
+            if (anc.getObject() instanceof PseudoRun) {
+                if (f == null) f = anc;
+                l = anc;
+            }
+        }
+        if (l == null) return null;    // there was no Run object
+
+        String base = l.getUrl();
+
+        return new RunUrl(base);
+
+    }
+
+    /**
+     * Gets the string that says how long since this build has started.
+     *
+     * @return string like "3 minutes" "1 day" etc.
+     */
+    @Nonnull
+    public String getTimestampString() {
+        long duration = new GregorianCalendar().getTimeInMillis() - computation.getTimestamp().getTimeInMillis();
+        return Util.getPastTimeString(duration);
+    }
+
+    /**
+     * Returns the timestamp formatted in xs:dateTime.
+     *
+     * @return the timestamp formatted in xs:dateTime.
+     */
+    @Nonnull
+    public String getTimestampString2() {
+        return Util.XS_DATETIME_FORMATTER.format(computation.getTimestamp());
+    }
+
+    @CheckForNull
+    public Result getResult() {
+        return computation.getResult();
+    }
+
+    @Nonnull
+    public Calendar getTimestamp() {
+        return computation.getTimestamp();
+    }
+
+    @Nonnull
+    public String getDurationString() {
+        return computation.getDurationString();
+    }
+
+    @Override
+    public String getSearchUrl() {
+        return computation.getSearchUrl();
+    }
+
+    @Nonnull
+    public File getLogFile() {
+        return computation.getLogFile();
+    }
+
+    @Override
+    public Object getStaplerFallback() {
+        return computation;
+    }
+
+    public HttpResponse doIndex(StaplerRequest request) {
+        return HttpResponses.redirectTo(Jenkins.getActiveInstance().getRootUrlFromRequest() + computation.getUrl() );
+    }
+
+    public HttpResponse doConsole(StaplerRequest request) {
+        return HttpResponses.redirectTo(Jenkins.getActiveInstance().getRootUrlFromRequest() + computation.getUrl() + "console");
+    }
+
+    public HttpResponse doConsoleText(StaplerRequest request) {
+        return HttpResponses.redirectTo(Jenkins.getActiveInstance().getRootUrlFromRequest() + computation.getUrl() + "consoleText");
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static final class RunUrl {
+        private final String base;
+
+
+        public RunUrl(String base) {
+            this.base = base;
+        }
+
+        public String getBaseUrl() {
+            return base;
+        }
+
+        /**
+         * Returns the same page in the next build.
+         */
+        public String getNextBuildUrl() {
+            return null;
+        }
+
+        /**
+         * Returns the same page in the previous build.
+         */
+        public String getPreviousBuildUrl() {
+            return null;
+        }
+
+    }
+
+}

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/Messages.properties
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/Messages.properties
@@ -2,3 +2,4 @@ ComputedFolder.already_computing=Already computing
 FolderComputation.DisplayName=Folder Computation
 ThrottleComputationQueueTaskDispatcher.MaxConcurrentIndexing=At maximum indexing capacity
 PeriodicFolderTrigger.DisplayName=Periodically if not otherwise run
+PseudoRun.DisplayName=log

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/PseudoRun/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/PseudoRun/sidepanel.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright 2013-2016 CloudBees, Inc.
+Copyright (c) 2017 CloudBees, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -21,21 +21,17 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:this="this">
-
-    <j:set var="computation" value="${it.computation}"/>
-
-    <l:task icon="images/24x24/notepad.png" href="${rootURL}/${computation.url}" title="${computation.displayName}">
-        <j:if test="${h.hasPermission(it, it.BUILD) and it.buildable}">
-            <l:task icon="images/24x24/clock.png" href="${rootURL}/${it.url}build?delay=0" post="true" title="${%Run Now}"/>
-        </j:if>
-        <l:task icon="images/24x24/terminal.png" href="${rootURL}/${computation.url}console" title="${%Log}">
-            <l:task href="${rootURL}/${computation.url}consoleText" icon="icon-document icon-md" title="${%View as plain text}"/>
-        </l:task>
-        <j:if test="${it.hasEvents}">
-            <l:task icon="images/24x24/monitor.png" href="${rootURL}/${computation.url}events" title="${%Events}"/>
-        </j:if>
-    </l:task>
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+  <l:header/>
+  <l:side-panel>
+    <l:tasks>
+      <j:set var="buildUrl" value="${it.decompose(request)}"/>
+      <p:console-link/>
+      <st:include page="actions.jelly"/>
+      <t:actions actions="${it.transientActions}"/>
+    </l:tasks>
+  </l:side-panel>
 </j:jelly>


### PR DESCRIPTION
See [JENKINS-37369](https://issues.jenkins-ci.org/browse/JENKINS-37369)

@reviewbybees

Exposes the last computation information (so will only ever be either success or failure until we add computation history support) 

![screen shot 2017-02-27 at 13 18 07](https://cloud.githubusercontent.com/assets/209336/23362758/3b2ec088-fcef-11e6-825c-c819cb1ff36f.png)
