### PR TITLE
[JENKINS-42511] Race condition in PeriodicFolderTrigger

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -550,6 +550,7 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
     public final FolderComputation<I> createExecutable() throws IOException {
         FolderComputation<I> c = createComputation(computation);
         computation = c;
+        LOGGER.log(Level.FINE, "Recording {0} @{1}", new Object[] {c, c.getTimestamp()});
         return c;
     }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
@@ -58,7 +58,7 @@ public class PeriodicFolderTrigger extends Trigger<ComputedFolder<?>> {
      * Normally we rely on {@link FolderComputation#getTimestamp} but there is a slight delay
      * between {@link ComputedFolder#scheduleBuild(int, Cause)} and {@link ComputedFolder#createExecutable}.
      */
-    private transient long lastTriggered;
+    private transient long lastTriggered; // could be volatile or AtomicLong, but FolderCron will not run >1 concurrently anyway
 
     /**
      * Constructor.

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
@@ -25,6 +25,7 @@ package com.cloudbees.hudson.plugins.folder.computed;
 
 import antlr.ANTLRException;
 import hudson.Extension;
+import hudson.model.Cause;
 import hudson.model.Item;
 import hudson.model.Items;
 import hudson.triggers.TimerTrigger;
@@ -32,6 +33,8 @@ import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.ListBoxModel;
 import hudson.util.TimeUnit2;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -43,10 +46,19 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class PeriodicFolderTrigger extends Trigger<ComputedFolder<?>> {
 
+    private static final Logger LOGGER = Logger.getLogger(PeriodicFolderTrigger.class.getName());
+
     /**
      * The interval between successive indexings.
      */
     private final long interval;
+
+    /**
+     * Timestamp when we last {@link #run}.
+     * Normally we rely on {@link FolderComputation#getTimestamp} but there is a slight delay
+     * between {@link ComputedFolder#scheduleBuild(int, Cause)} and {@link ComputedFolder#createExecutable}.
+     */
+    private transient long lastTriggered;
 
     /**
      * Constructor.
@@ -159,14 +171,24 @@ public class PeriodicFolderTrigger extends Trigger<ComputedFolder<?>> {
      */
     @Override
     public void run() {
+        long now = System.currentTimeMillis();
         FolderComputation<?> computation = job.getComputation();
         if (computation != null) {
-            long delay = System.currentTimeMillis() - computation.getTimestamp().getTimeInMillis();
+            long delay = now - computation.getTimestamp().getTimeInMillis();
             if (delay < interval) {
+                LOGGER.log(Level.FINE, "Too early to reschedule {0} based on last computation", job);
                 return;
             }
         }
-        job.scheduleBuild(0, new TimerTrigger.TimerTriggerCause());
+        if (now - lastTriggered < interval) {
+            LOGGER.log(Level.FINE, "Too early to reschedule {0} based on last triggering", job);
+            return;
+        }
+        if (job.scheduleBuild(0, new TimerTrigger.TimerTriggerCause())) {
+            lastTriggered = now;
+        } else {
+            LOGGER.log(Level.WARNING, "Queue refused to schedule {0}", job);
+        }
     }
 
     /**


### PR DESCRIPTION
[JENKINS-42511](https://issues.jenkins-ci.org/browse/JENKINS-42511)

Fixes the problem I observed in the demo, with a once-per-minute trigger:

* cron checking Tue Mar 07 15:43:00 UTC 2017
* cron checking `WorkflowMultiBranchProject[cd]`
* scheduling `WorkflowMultiBranchProject[cd]`
* cron checking Tue Mar 07 15:44:00 UTC 2017
* cron checking `WorkflowMultiBranchProject[cd]`
* scheduling `WorkflowMultiBranchProject[cd]`
* `createExecutable` on `WorkflowMultiBranchProject[cd]`
* `createExecutable` on `WorkflowMultiBranchProject[cd]`

`FolderCron`, like the core `Cron` it was copied from, diligently reruns triggers for every discrete minute that they might have matched. If you have a trigger with a short frequency, especially one minute (the same as the period for `FolderCron`), it will frequently happen that `PeriodicFolderTrigger.run` is called twice in quick succession. In that case, one of three things will happen:

* The second call to `scheduleBuild` will arrive while the first task is still in `Queue`, so it is ignored. (Should return `true` but it is a `ScheduleResult.Existing`.)
* The `Queue` moves fast and the `createExecutable` from the first call is already complete by the time the second `run` is called, so there is already a recent `FolderComputation` and `scheduleBuild` is not called again.
* The first task has been sent to a (flyweight) executor, but `createExecutable` has not been called or has not yet completed, so `run` thinks there is no recent computation and calls `scheduleBuild` again. This posts another task to the queue, causing another indexing immediately after the first. That apparently triggers another race condition in concurrent indexing, and without https://github.com/jenkinsci/branch-api-plugin/pull/92 you get into an inconsistent state.

Thanks to @stephenc for tipping me off to `FolderCron`. This fix does _not_ cover the case that a timed indexing coincides with a manual trigger or an SCM event.

Probably reproduced, and fix confirmed, in `workflow-aggregator-plugin/demo`.

@reviewbybees