### PR TITLE
[JENKINS-42593] Reinitialize transient lock-related fields after restart

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -127,20 +127,20 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
      * @since 6.0.0
      */
     @Nonnull
-    private transient final ReentrantLock currentObservationsLock = new ReentrantLock();
+    private transient /* almost final */ ReentrantLock currentObservationsLock;
     /**
      * Condition to flag whenever the {@link #currentObservationsChanged} has had elements removed.
      *
      * @since 6.0.0
      */
-    private transient final Condition currentObservationsChanged = currentObservationsLock.newCondition();
+    private transient /* almost final */ Condition currentObservationsChanged;
     /**
      * The names of the child items that are currently being observed.
      *
      * @since 6.0.0
      */
     @GuardedBy("#computationLock")
-    private transient final Set<String> currentObservations = new HashSet<>();
+    private transient /* almost final */ Set<String> currentObservations;
     /**
      * Flag set when the implementation uses {@link #createEventsChildObserver()} and not
      * {@link #openEventsChildObserver()}, when {@code true} then the {@link #currentObservations} is ignored
@@ -149,7 +149,7 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
      * @since 6.0.0
      */
     @GuardedBy("#computationLock")
-    private transient boolean currentObservationsLockDisabled = false;
+    private transient boolean currentObservationsLockDisabled;
 
     /**
      * Tracks recalculation requirements in {@link #doConfigSubmit(StaplerRequest, StaplerResponse)}.
@@ -187,6 +187,9 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
         synchronized (this) {
             computation = createComputation(null);
         }
+        currentObservationsLock = new ReentrantLock();
+        currentObservationsChanged = currentObservationsLock.newCondition();
+        currentObservations = new HashSet<>();
     }
 
     @Override

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
@@ -56,8 +56,8 @@ public class ComputedFolder2Test {
             public void evaluate() throws Throwable {
                 EventableFolder d = rr.j.jenkins.createProject(EventableFolder.class, "d");
                 d.add("one");
-                ComputedFolderTest.doRecompute(d, Result.SUCCESS);
-                assertThat(d.getItems(), hasSize(equalTo(1)));
+                String log = ComputedFolderTest.doRecompute(d, Result.SUCCESS);
+                assertThat(log, d.getItems(), hasSize(equalTo(1)));
             }
         });
         rr.addStep(new Statement() {
@@ -67,8 +67,8 @@ public class ComputedFolder2Test {
                 assertNotNull(d);
                 assertThat(d.getItems(), hasSize(equalTo(1)));
                 d.add("two");
-                ComputedFolderTest.doRecompute(d, Result.SUCCESS);
-                assertThat(d.getItems(), hasSize(equalTo(1)));
+                String log = ComputedFolderTest.doRecompute(d, Result.SUCCESS);
+                assertThat(log, d.getItems(), hasSize(equalTo(1)));
             }
         });
     }
@@ -108,6 +108,7 @@ public class ComputedFolder2Test {
                     if (p == null) {
                         if (observer.mayCreate(kid)) {
                             listener.getLogger().println("adding " + kid);
+                            kids.add(kid);
                             p = new FreeStyleProject(this, kid);
                             observer.created(p);
                         }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
@@ -110,7 +110,6 @@ public class ComputedFolder2Test {
                             listener.getLogger().println("adding " + kid);
                             p = new FreeStyleProject(this, kid);
                             observer.created(p);
-                            p.scheduleBuild2(0);
                         }
                     }
                 } finally {

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
@@ -1,0 +1,134 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.hudson.plugins.folder.computed;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolderDescriptor;
+import hudson.model.FreeStyleProject;
+import hudson.model.ItemGroup;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.model.TopLevelItem;
+import hudson.util.StreamTaskListener;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+public class ComputedFolder2Test {
+
+    @Rule
+    public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+
+    @Issue("JENKINS-42593")
+    @Test
+    public void eventAfterRestart() {
+        rr.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                EventableFolder d = rr.j.jenkins.createProject(EventableFolder.class, "d");
+                d.add("one");
+                ComputedFolderTest.doRecompute(d, Result.SUCCESS);
+                assertThat(d.getItems(), hasSize(equalTo(1)));
+            }
+        });
+        rr.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                EventableFolder d = rr.j.jenkins.getItemByFullName("d", EventableFolder.class);
+                assertNotNull(d);
+                assertThat(d.getItems(), hasSize(equalTo(1)));
+                d.add("two");
+                ComputedFolderTest.doRecompute(d, Result.SUCCESS);
+                assertThat(d.getItems(), hasSize(equalTo(1)));
+            }
+        });
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static final class EventableFolder extends ComputedFolder<FreeStyleProject> {
+
+        private final List<String> kids = new ArrayList<>();
+
+        public EventableFolder(ItemGroup parent, String name) {
+            super(parent, name);
+        }
+
+        @Override
+        protected void computeChildren(ChildObserver<FreeStyleProject> observer, TaskListener listener) throws IOException, InterruptedException {
+            for (String kid : kids) {
+                FreeStyleProject p = observer.shouldUpdate(kid);
+                try {
+                    if (p == null) {
+                        if (observer.mayCreate(kid)) {
+                            listener.getLogger().println("loading " + kid);
+                            p = new FreeStyleProject(this, kid);
+                            observer.created(p);
+                        }
+                    }
+                } finally {
+                    observer.completed(kid);
+                }
+            }
+        }
+
+        public void add(String kid) throws IOException, InterruptedException {
+            try (StreamTaskListener listener = getComputation().createEventsListener();
+                    ChildObserver<FreeStyleProject> observer = openEventsChildObserver()) {
+                FreeStyleProject p = observer.shouldUpdate(kid);
+                try {
+                    if (p == null) {
+                        if (observer.mayCreate(kid)) {
+                            listener.getLogger().println("adding " + kid);
+                            p = new FreeStyleProject(this, kid);
+                            observer.created(p);
+                            p.scheduleBuild2(0);
+                        }
+                    }
+                } finally {
+                    observer.completed(kid);
+                }
+            }
+        }
+
+        @TestExtension("eventAfterRestart")
+        public static final class DescriptorImpl extends AbstractFolderDescriptor {
+
+            @Override
+            public TopLevelItem newInstance(ItemGroup parent, String name) {
+                return new EventableFolder(parent, name);
+            }
+
+        }
+
+    }
+
+}

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -651,7 +651,7 @@ public class ComputedFolderTest {
         }
     }
 
-    private static String doRecompute(ComputedFolder<?> d, Result result) throws Exception {
+    static String doRecompute(ComputedFolder<?> d, Result result) throws Exception {
         d.scheduleBuild2(0).getFuture().get();
         FolderComputation<?> computation = d.getComputation();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
[JENKINS-42593](https://issues.jenkins-ci.org/browse/JENKINS-42593)

Fixes a critical regression in #92.

@reviewbybees