### PR TITLE
Fix test not meeting expected conditions.

### DIFF
--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/EventOutputStreamsTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/EventOutputStreamsTest.java
@@ -59,7 +59,7 @@ public class EventOutputStreamsTest {
 
     @Test
     public void given_oneFlushing_when_twoThreads_then_outputCorrect() throws Exception {
-        test(false, false);
+        test(true, false);
     }
 
     public void test(final boolean aFlush, final boolean bFlush) throws Exception {


### PR DESCRIPTION
Test for EventOutputStream was passing incorrect parameters to helper method.

@reviewbybees @stephenc @jglick 