### PR TITLE
[FIXED JENKINS-45984] Fix the crazy logic where 0 was semantically equivalent to 'empty' but actually wasn't

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -186,7 +186,7 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
     protected final void init() {
         super.init();
         if (orphanedItemStrategy == null) {
-            orphanedItemStrategy = new DefaultOrphanedItemStrategy(true, "0", "0");
+            orphanedItemStrategy = new DefaultOrphanedItemStrategy(true, "", "");
         }
         if (triggers == null) {
             triggers = new DescribableList<Trigger<?>,TriggerDescriptor>(this);


### PR DESCRIPTION
- All this crazy just to match the way LogRotator in core behaves

See [JENKINS-45984](https://issues.jenkins-ci.org/browse/JENKINS-45984)

@reviewbybees