### PR TITLE
[JENKINS-46933] Fix icon-shim dependency the hard way

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,21 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-      <artifactId>icon-shim</artifactId>
+      <artifactId>icon-set</artifactId>
+      <version>1.0.5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+       <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
+       <artifactId>icon-shim</artifactId>
       <version>2.0.3</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
+          <artifactId>icon-set</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,26 +59,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
-      <version>1.6</version>
+      <version>2.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-      <artifactId>icon-set</artifactId>
-      <version>1.0.5</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-       <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-       <artifactId>icon-shim</artifactId>
-      <version>2.0.3</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-          <artifactId>icon-set</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
#107 by @fcojfernandez was not in fact correct. Easily seen from `hpi:run` after viewing the index page of a folder:

```
java.lang.IllegalAccessError: tried to access method org.jenkins.ui.icon.IconSet.getIconByClassSpec(Ljava/lang/String;)Lorg/jenkins/ui/icon/Icon; from class com.cloudbees.hudson.plugins.folder.FolderIcon
	at com.cloudbees.hudson.plugins.folder.FolderIcon.iconClassNameImageOf(FolderIcon.java:80)
```

Cf. https://github.com/jenkinsci/plugin-pom/pull/72. `getIconByClassSpec` changed signature in 2.0.2, incompatibly by reverting an incompatible change in 1.0.5. Core still bundles `icon-set:1.0.5` with the `Object` signature. There is a 2.x plugin with an incompatible signature for some reason. Since `FolderIcon` actually has to compile against one or the other, it needs to pick the one it can actually link against in core. Yet `matrix-auth` declares a dependency against `icon-shim:2.0.3`, so we need to provide that as a `test`-scoped dependency as well to allow Jenkins to start in test mode. Checked with

```sh
mvn clean package
mvn -Djenkins.version=2.73.1 surefire:test # like PCT
mvn hpi:run
mvn -Djenkins.version=2.73.1 hpi:run
```

and also running both 1.642.3 and 2.73.1 with this snapshot installed.

@reviewbybees