### PR TITLE
[JENKINS-47416] Use a patched copy of the core API for now

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -248,7 +248,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         if (folderViews == null) {
             if (views != null && !views.isEmpty()) {
                 if (primaryView != null) {
-                    primaryView = AllView.migrateLegacyPrimaryAllViewLocalizedName(views, primaryView);
+                    primaryView = DefaultFolderViewHolder.migrateLegacyPrimaryAllViewLocalizedName(views, primaryView);
                 }
                 folderViews = new DefaultFolderViewHolder(views, primaryView, viewsTabBar == null ? newDefaultViewsTabBar()
                         : viewsTabBar);

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolder.java
@@ -30,10 +30,18 @@ import hudson.model.AllView;
 import hudson.model.View;
 import hudson.views.ViewsTabBar;
 import java.io.ObjectStreamException;
+import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+import jenkins.util.SystemProperties;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -130,8 +138,58 @@ public class DefaultFolderViewHolder extends AbstractFolderViewHolder {
 
     private Object readResolve() throws ObjectStreamException {
         if (primaryView != null) {
-            primaryView = AllView.migrateLegacyPrimaryAllViewLocalizedName(views, primaryView);
+            primaryView = migrateLegacyPrimaryAllViewLocalizedName(views, primaryView);
         }
         return this;
     }
+
+    // TODO use method in AllView once baseline has https://github.com/jenkinsci/jenkins/pull/3088
+    @Restricted(NoExternalUse.class)
+    @Nonnull
+    public static String migrateLegacyPrimaryAllViewLocalizedName(@Nonnull List<View> views,
+                                                                  @Nonnull String primaryView) {
+        if (AllView.DEFAULT_VIEW_NAME.equals(primaryView)) {
+            // modern name, we are safe
+            return primaryView;
+        }
+        if (SystemProperties.getBoolean(AllView.class.getName()+".JENKINS-38606", true)) {
+            AllView allView = null;
+            for (View v : views) {
+                if (AllView.DEFAULT_VIEW_NAME.equals(v.getViewName())) {
+                    // name conflict, we cannot rename the all view anyway
+                    return primaryView;
+                }
+                if (StringUtils.equals(v.getViewName(), primaryView)) {
+                    if (v instanceof AllView) {
+                        allView = (AllView) v;
+                    } else {
+                        // none of our business fixing as we can only safely fix the primary view
+                        return primaryView;
+                    }
+                }
+            }
+            if (allView != null) {
+                // the primary view is an AllView but using a non-default name
+                for (Locale l : Locale.getAvailableLocales()) {
+                    if (primaryView.equals(hudson.model.Messages._Hudson_ViewName().toString(l))) {
+                        // bingo JENKINS-38606 detected
+                        LOGGER.log(Level.INFO,
+                                "JENKINS-38606 detected for AllView in {0}; renaming view from {1} to {2}",
+                                new Object[]{allView.getOwner(), primaryView, AllView.DEFAULT_VIEW_NAME}); // PATCHED
+                        try {
+                            Field name = View.class.getDeclaredField("name");
+                            name.setAccessible(true);
+                            name.set(allView, AllView.DEFAULT_VIEW_NAME);
+                        } catch (Exception x) {
+                            LOGGER.log(Level.WARNING, null, x);
+                            return primaryView;
+                        }
+                        return AllView.DEFAULT_VIEW_NAME;
+                    }
+                }
+            }
+        }
+        return primaryView;
+    }
+
 }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolderTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.hudson.plugins.folder.views;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.diagnosis.OldDataMonitor;
+import hudson.model.AdministrativeMonitor;
+import hudson.model.AllView;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+public class DefaultFolderViewHolderTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-47416")
+    @LocalData
+    @Test
+    public void oldData() throws Exception {
+        Folder d = r.jenkins.getItemByFullName("d", Folder.class);
+        assertEquals(AllView.DEFAULT_VIEW_NAME, d.getPrimaryView().getViewName());
+        for (OldDataMonitor.VersionRange problem : AdministrativeMonitor.all().get(OldDataMonitor.class).getData().values()) {
+            fail(problem.extra);
+        }
+    }
+
+}

--- a/src/test/resources/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolderTest/oldData/jobs/d/config.xml
+++ b/src/test/resources/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolderTest/oldData/jobs/d/config.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.2.0">
+  <actions/>
+  <description></description>
+  <properties/>
+  <folderViews class="com.cloudbees.hudson.plugins.folder.views.DefaultFolderViewHolder">
+    <views>
+      <hudson.model.AllView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>All</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+      </hudson.model.AllView>
+      <hudson.model.ListView>
+        <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+        <name>other</name>
+        <filterExecutors>false</filterExecutors>
+        <filterQueue>false</filterQueue>
+        <properties class="hudson.model.View$PropertyList"/>
+        <jobNames>
+          <comparator class="hudson.util.CaseInsensitiveComparator"/>
+        </jobNames>
+        <jobFilters/>
+        <columns>
+          <hudson.views.StatusColumn/>
+          <hudson.views.WeatherColumn/>
+          <hudson.views.JobColumn/>
+          <hudson.views.LastSuccessColumn/>
+          <hudson.views.LastFailureColumn/>
+          <hudson.views.LastDurationColumn/>
+          <hudson.views.BuildButtonColumn/>
+        </columns>
+        <recurse>false</recurse>
+      </hudson.model.ListView>
+    </views>
+    <primaryView>All</primaryView>
+    <tabBar class="hudson.views.DefaultViewsTabBar"/>
+  </folderViews>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+      <nonRecursive>false</nonRecursive>
+    </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+  </healthMetrics>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>


### PR DESCRIPTION
[JENKINS-47416](https://issues.jenkins-ci.org/browse/JENKINS-47416)

Pending https://github.com/jenkinsci/jenkins/pull/3088, correct a regression in #112 of a sort; the exception was already being thrown as of #79, but swallowed.

@reviewbybees