### PR TITLE
Allow implementations do initialisation additions

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -184,7 +184,7 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
      * {@inheritDoc}
      */
     @Override
-    protected final void init() {
+    protected void init() {
         super.init();
         if (orphanedItemStrategy == null) {
             orphanedItemStrategy = new DefaultOrphanedItemStrategy(true, "", "");


### PR DESCRIPTION
@jglick is there any blocker to make it non-final?
`super.init()` is not final but this override blocks ability to make aditional initialisations right after job was moved and has new `parent, name`. 


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/cloudbees-folder-plugin/121)
<!-- Reviewable:end -->
