### PR TITLE
Fix TimeDuration#getTime() call

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -548,7 +548,7 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
         if (!isBuildable()) {
             throw HttpResponses.error(SC_INTERNAL_SERVER_ERROR, new IOException(getFullName() + " cannot be recomputed"));
         }
-        scheduleBuild2(delay == null ? 0 : delay.getTime(), new CauseAction(new Cause.UserIdCause()));
+        scheduleBuild2(delay == null ? 0 : delay.getTimeInSeconds(), new CauseAction(new Cause.UserIdCause()));
         return HttpResponses.forwardToPreviousPage();
     }
 


### PR DESCRIPTION
This method is deprecated. See quote:
"This method has always returned a time in milliseconds, when various
callers incorrectly assumed seconds. And this spread through the
codebase. So this has been deprecated for clarity in favour of more
explicitly named methods."

According to the Javadoc of scheduleBuild2() the unit of quietPeriod is
seconds whereas getTime() returned seconds. This looks like a bug.
Therefore now using getTimeInSeconds() instead of getTimeInMillis().