### PR TITLE
[JENKINS-58282] Ability to configure default folder health metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,13 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>1.29</version>
+      <version>1.30</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>1.29</version>
+      <version>1.30</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,19 @@
       <version>2.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.29</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.29</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -25,6 +25,7 @@
 package com.cloudbees.hudson.plugins.folder;
 
 import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
+import com.cloudbees.hudson.plugins.folder.config.AbstractFolderConfiguration;
 import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric;
 import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
 import com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon;
@@ -287,15 +288,9 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
                 }
             }
         };
+        
         if (healthMetrics == null) {
-            List<FolderHealthMetric> metrics = new ArrayList<FolderHealthMetric>();
-            for (FolderHealthMetricDescriptor d : FolderHealthMetricDescriptor.all()) {
-                FolderHealthMetric metric = d.createDefault();
-                if (metric != null) {
-                    metrics.add(metric);
-                }
-            }
-            healthMetrics = new DescribableList<FolderHealthMetric, FolderHealthMetricDescriptor>(this, metrics);
+            healthMetrics = new DescribableList<>(this, AbstractFolderConfiguration.get().getHealthMetrics());
         }
     }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
@@ -1,0 +1,56 @@
+package com.cloudbees.hudson.plugins.folder.config;
+
+import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric;
+import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
+import hudson.Extension;
+import hudson.util.DescribableList;
+import jenkins.model.GlobalConfiguration;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Extension @Symbol("defaultFolderConfiguration")
+public class AbstractFolderConfiguration extends GlobalConfiguration {
+
+    private List<FolderHealthMetric> healthMetrics;
+    
+    @Nonnull
+    public static AbstractFolderConfiguration get() {
+        AbstractFolderConfiguration instance = GlobalConfiguration.all().get(AbstractFolderConfiguration.class);
+        if (instance == null) {
+            throw new IllegalStateException();
+        }
+        return instance;
+    }
+
+    @DataBoundConstructor
+    public AbstractFolderConfiguration() {
+        load();
+        if (healthMetrics == null) {
+            List<FolderHealthMetric> metrics = new ArrayList<>();
+            for (FolderHealthMetricDescriptor d : FolderHealthMetricDescriptor.all()) {
+                FolderHealthMetric metric = d.createDefault();
+                if (metric != null) {
+                    metrics.add(metric);
+                }
+            }
+            healthMetrics = new DescribableList<FolderHealthMetric, FolderHealthMetricDescriptor>(this, metrics);
+        }
+    }
+    
+    @Nonnull
+    public List<FolderHealthMetric> getHealthMetrics() {
+        return healthMetrics == null ? Collections.emptyList() : healthMetrics;
+    }
+    
+    @DataBoundSetter
+    public void setHealthMetrics(List<FolderHealthMetric> healthMetrics) {
+        this.healthMetrics = healthMetrics;
+        save();
+    }
+}

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration/config.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration/config.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:section title="${%Folder}">
+        <f:entry title="${%Health Metrics}"
+                 description="${%List of default health metrics for Folders}">
+            <f:repeatableHeteroProperty field="healthMetrics" oneEach="true" honorOrder="true" hasHeader="true">
+                <f:entry title="">
+                    <div align="right">
+                        <f:repeatableDeleteButton/>
+                    </div>
+                </f:entry>
+            </f:repeatableHeteroProperty>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ConfigurationAsCodeTest.java
@@ -1,0 +1,32 @@
+package com.cloudbees.hudson.plugins.folder;
+
+import com.cloudbees.hudson.plugins.folder.config.AbstractFolderConfiguration;
+import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric;
+import com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+public class ConfigurationAsCodeTest extends RoundTripAbstractTest {
+
+    @Override
+    protected String stringInLogExpected() {
+        return "Setting class com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric. recursive = false";
+    }
+
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        List<FolderHealthMetric> healthMetrics = AbstractFolderConfiguration.get().getHealthMetrics();
+        assertThat(healthMetrics, hasSize(1));
+        assertThat(healthMetrics.get(0), instanceOf(WorstChildHealthMetric.class));
+        WorstChildHealthMetric worstChildHealthMetric = (WorstChildHealthMetric) healthMetrics.get(0);
+        assertFalse(worstChildHealthMetric.isRecursive());
+    }
+
+}

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ConfigurationAsCodeTest.java
@@ -17,7 +17,7 @@ public class ConfigurationAsCodeTest extends RoundTripAbstractTest {
 
     @Override
     protected String stringInLogExpected() {
-        return "Setting class com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric. recursive = false";
+        return "Setting class com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric.recursive = false";
     }
 
     @Override

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -24,6 +24,10 @@
 
 package com.cloudbees.hudson.plugins.folder;
 
+import com.cloudbees.hudson.plugins.folder.config.AbstractFolderConfiguration;
+import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric;
+import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
+import com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric;
 import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainCredentials;
 import com.gargoylesoftware.htmlunit.HttpMethod;
@@ -44,6 +48,7 @@ import hudson.security.WhoAmI;
 import hudson.security.Permission;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import hudson.tasks.BuildTrigger;
+import hudson.util.DescribableList;
 import hudson.views.BuildButtonColumn;
 import hudson.views.JobColumn;
 import java.io.IOException;
@@ -407,6 +412,23 @@ public class FolderTest {
 
         anchor = findRenameAnchor(folder1); // Throws ElementNotFoundException before JENKINS-52164 fix
         anchor.click();
+    }
+
+    @Issue("JENKINS-58282")
+    @Test public void shouldHaveHealthMetricConfiguredGloballyOnCreation() throws Exception {
+        assertThat("by default, global configuration should have all folder health metrics",
+                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(FolderHealthMetricDescriptor.all().size()));
+        
+        Folder folder = r.jenkins.createProject(Folder.class, "myFolder");
+        DescribableList<FolderHealthMetric, FolderHealthMetricDescriptor> healthMetrics = folder.getHealthMetrics();
+        assertThat("a new created folder should have all the folder health metrics configured globally",
+                healthMetrics.toList(), containsInAnyOrder(AbstractFolderConfiguration.get().getHealthMetrics().toArray()));
+
+        AbstractFolderConfiguration.get().setHealthMetrics(null);
+        folder = r.jenkins.createProject(Folder.class, "myFolder2");
+        healthMetrics = folder.getHealthMetrics();
+        assertThat("a new created folder should have all the folder health metrics configured globally",
+                healthMetrics, iterableWithSize(0));
     }
 
     /**

--- a/src/test/resources/com/cloudbees/hudson/plugins/folder/configuration-as-code.yaml
+++ b/src/test/resources/com/cloudbees/hudson/plugins/folder/configuration-as-code.yaml
@@ -1,0 +1,5 @@
+unclassified:
+  defaultFolderConfiguration:
+    healthMetrics:
+      - worstChildHealthMetric:
+          recursive: false


### PR DESCRIPTION
See [JENKINS-58282](https://issues.jenkins-ci.org/browse/JENKINS-58282). Large instances are awfully impacted by performances issues related to health metrics. As a workaround, the health metrics can be removed but every time a new folder is created, it has all folder health metrics configured and there is no way around this. This feature is meant to help administrator to control this.

### Proposed changelog entries

* Ability to configure default folder health metrics

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez