### PR TITLE
Example of using latest plugin-pom and Jenkins bom

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Duse-jenkins-bom

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>4.0-SNAPSHOT</version>
     <relativePath />
   </parent>
 
@@ -19,7 +19,7 @@
   </description>
   <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
   <properties>
-    <jenkins.version>2.130</jenkins.version>
+    <jenkins.version>2.190-SNAPSHOT</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>
@@ -50,7 +50,31 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-bom</artifactId>
+        <version>${jenkins.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+    <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+      </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </description>
   <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
   <properties>
-    <jenkins.version>2.190-SNAPSHOT</jenkins.version>
+    <jenkins.version>2.194-SNAPSHOT</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>
@@ -64,9 +64,10 @@
 
   <dependencies>
     <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-      </dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <version>4.0.0.Beta5</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -860,7 +860,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         if (getView(view) == null) {
             return FormValidation.ok();
         } else {
-            return FormValidation.error(jenkins.model.Messages.Hudson_ViewAlreadyExists(view));
+            return FormValidation.error(Messages.Folder_ViewAlreadyExists(view));
         }
     }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
@@ -143,8 +143,8 @@ public class Folder extends AbstractFolder<TopLevelItem> implements DirectlyModi
         updateTransientActions();
     }
 
-    @Restricted(DoNotUse.class)
-    @Deprecated
+//    @Restricted(DoNotUse.class)
+//    @Deprecated
     @Extension
     public static class DeprecatedTransientActions extends TransientActionFactory<Folder> {
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
@@ -433,7 +433,7 @@ public class FolderComputation<I extends TopLevelItem> extends Actionable implem
     @Nonnull
     public String getDurationString() {
         if (isBuilding()) {
-            return hudson.model.Messages.Run_InProgressDuration(Util.getTimeSpanString(System.currentTimeMillis() - timestamp));
+            return Messages.Run_InProgressDuration(Util.getTimeSpanString(System.currentTimeMillis() - timestamp));
         } else {
             return Util.getTimeSpanString(duration);
         }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolder.java
@@ -152,7 +152,9 @@ public class DefaultFolderViewHolder extends AbstractFolderViewHolder {
             // modern name, we are safe
             return primaryView;
         }
-        if (SystemProperties.getBoolean(AllView.class.getName()+".JENKINS-38606", true)) {
+        boolean jenkins38606 = Boolean.parseBoolean(System.getProperty(AllView.class.getName()+".JENKINS-38606",
+                                                                       "true"));
+        if (jenkins38606) {
             AllView allView = null;
             for (View v : views) {
                 if (AllView.DEFAULT_VIEW_NAME.equals(v.getViewName())) {
@@ -171,7 +173,7 @@ public class DefaultFolderViewHolder extends AbstractFolderViewHolder {
             if (allView != null) {
                 // the primary view is an AllView but using a non-default name
                 for (Locale l : Locale.getAvailableLocales()) {
-                    if (primaryView.equals(hudson.model.Messages._Hudson_ViewName().toString(l))) {
+                    if (primaryView.equals(Messages._Folder_ViewName().toString(l))) {
                         // bingo JENKINS-38606 detected
                         LOGGER.log(Level.INFO,
                                 "JENKINS-38606 detected for AllView in {0}; renaming view from {1} to {2}",

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/Messages.properties
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/Messages.properties
@@ -9,3 +9,6 @@ Folder.Description=Creates a container that stores nested items in it. Useful fo
 
 RelocateAction.permission.desc=Required to move a job from one folder (or Jenkins root) to another.
 RelocateAction.displayName=Move
+
+
+Folder.ViewAlreadyExists=A view already exists with the name "{0}"

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/Messages.properties
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/Messages.properties
@@ -4,3 +4,5 @@ FolderComputation.DisplayName=Folder Computation
 ThrottleComputationQueueTaskDispatcher.MaxConcurrentIndexing=At maximum indexing capacity
 PeriodicFolderTrigger.DisplayName=Periodically if not otherwise run
 PseudoRun.DisplayName=log
+
+Run.InProgressDuration={0} and counting

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/views/Messages.properties
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/views/Messages.properties
@@ -1,0 +1,1 @@
+Folder.ViewName=All

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
@@ -69,6 +69,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 /**


### PR DESCRIPTION
Please do not merge, this is just an example showing how a plugin would consume the latest [plugin-pom](https://github.com/jenkinsci/plugin-pom/pull/229) & [Jenkins BOM](https://github.com/jenkinsci/jenkins/pull/4150).

c.f. [https://github.com/jenkinsci/cloudbees-folder-plugin/pull/131](https://github.com/jenkinsci/cloudbees-folder-plugin/pull/131)

The jenkins-bom is imported to synchronise dependencies with <jenkins.version> (so long as that is after the first version where the bom is added).
This shows the following benefits to the bom:
* Added dependency `resteasy-jaxrs` has a conflicting (with `jenkins-core`) dependency on `commons-io` - the correct version (2.6) from `jenkins-core` is used without having to specify here.
* Added dependency on `ant` - this will be synchronised to the `jenkins-core` required version without having to keep a version number in this pom synchronised.
* Added dependency on `slf4j-api`, without having to use `${slf4jVersion}` defined in `plugin-pom` which can become out of date as `jenkins-core` moves on.

(the code changes are just quick fixes to compile successfully against 2.190).
