### PR TITLE
[JENKINS-60393] Ensure all plugins are loaded to configure the defaults

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
@@ -35,15 +35,7 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
     @DataBoundConstructor
     public AbstractFolderConfiguration() {
         this.load();
-    }
-
-    /**
-     * Auto-configure the default metrics after all plugins have been loaded.
-     */
-    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
-    public static void autoConfigure() {
-        AbstractFolderConfiguration abstractFolderConfiguration = AbstractFolderConfiguration.get();
-        if (abstractFolderConfiguration.healthMetrics == null) {
+        if(healthMetrics == null) {
             List<FolderHealthMetric> metrics = new ArrayList<>();
             for (FolderHealthMetricDescriptor d : FolderHealthMetricDescriptor.all()) {
                 FolderHealthMetric metric = d.createDefault();
@@ -51,8 +43,8 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
                     metrics.add(metric);
                 }
             }
-            abstractFolderConfiguration.setHealthMetrics(new DescribableList<FolderHealthMetric,
-                    FolderHealthMetricDescriptor>(abstractFolderConfiguration, metrics));
+            setHealthMetrics(new DescribableList<FolderHealthMetric,
+                    FolderHealthMetricDescriptor>(this, metrics));
         }
     }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
@@ -7,9 +7,11 @@ import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.util.DescribableList;
 import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -63,5 +65,16 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
     public void setHealthMetrics(List<FolderHealthMetric> healthMetrics) {
         this.healthMetrics = healthMetrics;
         save();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) {
+        if(json.containsKey("healthMetrics")) {
+            req.bindJSON(this, json);
+            this.save();
+        } else {
+            this.setHealthMetrics(Collections.emptyList());
+        }
+        return true;
     }
 }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
@@ -35,7 +35,15 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
     @DataBoundConstructor
     public AbstractFolderConfiguration() {
         this.load();
-        if(healthMetrics == null) {
+    }
+
+    /**
+     * Auto-configure the default metrics after all plugins have been loaded.
+     */
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
+    public static void autoConfigure() {
+        AbstractFolderConfiguration abstractFolderConfiguration = AbstractFolderConfiguration.get();
+        if (abstractFolderConfiguration.healthMetrics == null) {
             List<FolderHealthMetric> metrics = new ArrayList<>();
             for (FolderHealthMetricDescriptor d : FolderHealthMetricDescriptor.all()) {
                 FolderHealthMetric metric = d.createDefault();
@@ -43,8 +51,8 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
                     metrics.add(metric);
                 }
             }
-            setHealthMetrics(new DescribableList<FolderHealthMetric,
-                    FolderHealthMetricDescriptor>(this, metrics));
+            abstractFolderConfiguration.setHealthMetrics(new DescribableList<FolderHealthMetric,
+                    FolderHealthMetricDescriptor>(abstractFolderConfiguration, metrics));
         }
     }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
@@ -36,7 +36,7 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
     }
 
     /**
-     * Auto-configure the default metrics afetr all plugins have been loaded.
+     * Auto-configure the default metrics after all plugins have been loaded.
      */
     @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
     public static void autoConfigure() {

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -27,7 +27,6 @@ package com.cloudbees.hudson.plugins.folder;
 import com.cloudbees.hudson.plugins.folder.config.AbstractFolderConfiguration;
 import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric;
 import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
-import com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric;
 import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainCredentials;
 import com.gargoylesoftware.htmlunit.HttpMethod;
@@ -429,6 +428,21 @@ public class FolderTest {
         healthMetrics = folder.getHealthMetrics();
         assertThat("a new created folder should have all the folder health metrics configured globally",
                 healthMetrics, iterableWithSize(0));
+    }
+
+    @Issue("JENKINS-60393")
+    @Test public void shouldBeAbleToRemoveHealthMetricConfiguredGlobally() throws Exception {
+        assertThat("by default, global configuration should have all folder health metrics",
+                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(FolderHealthMetricDescriptor.all().size()));
+
+        HtmlForm cfg = r.createWebClient().goTo("configure").getFormByName("config");
+        for (HtmlElement element : cfg.getElementsByAttribute("div", "name", "healthMetrics")) {
+            element.remove();
+        }
+        r.submit(cfg);
+        
+        assertThat("deleting all global metrics should result in an empty list",
+                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(0));
     }
 
     /**

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -430,21 +430,6 @@ public class FolderTest {
                 healthMetrics, iterableWithSize(0));
     }
 
-    @Issue("JENKINS-60393")
-    @Test public void shouldBeAbleToRemoveHealthMetricConfiguredGlobally() throws Exception {
-        assertThat("by default, global configuration should have all folder health metrics",
-                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(FolderHealthMetricDescriptor.all().size()));
-
-        HtmlForm cfg = r.createWebClient().goTo("configure").getFormByName("config");
-        for (HtmlElement element : cfg.getElementsByAttribute("div", "name", "healthMetrics")) {
-            element.remove();
-        }
-        r.submit(cfg);
-        
-        assertThat("deleting all global metrics should result in an empty list",
-                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(0));
-    }
-
     /**
      * Ensures that the specified property points to the folder.
      * @param <T> Property type

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfigurationTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfigurationTest.java
@@ -1,0 +1,80 @@
+package com.cloudbees.hudson.plugins.folder.config;
+
+import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import hudson.ExtensionFinder;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class AbstractFolderConfigurationTest {
+
+    private static final String GUICE_INITIALIZATION_MESSAGE =
+            "Failed to instantiate Key[type=" + AbstractFolderConfiguration.class.getName() + ", annotation=[none]];";
+    
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule().record(ExtensionFinder.GuiceFinder.class, Level.INFO).capture(100);
+
+    @Test
+    @Issue("JENKINS-60393")
+    public void testInitialization() {
+        assertThat("AbstractFolderConfiguration should not cause circular dependency on startup",
+                logging.getRecords().stream()
+                        .filter(lr -> lr.getLevel().intValue() == Level.WARNING.intValue())
+                        .filter(lr -> lr.getMessage().contains(GUICE_INITIALIZATION_MESSAGE))
+                        .map(lr -> lr.getSourceClassName() + "." + lr.getSourceMethodName() + ": " + lr.getMessage())
+                        .collect(Collectors.toList()),
+                emptyIterable());
+    }
+
+    @Issue("JENKINS-60393")
+    @Test
+    public void shouldBeAbleToRemoveHealthMetricConfiguredGlobally() throws Exception {
+        assertThat("by default, global configuration should have all folder health metrics",
+                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(FolderHealthMetricDescriptor.all().size()));
+
+        HtmlForm cfg = r.createWebClient().goTo("configure").getFormByName("config");
+        for (HtmlElement element : cfg.getElementsByAttribute("div", "name", "healthMetrics")) {
+            element.remove();
+        }
+        r.submit(cfg);
+
+        assertThat("deleting all global metrics should result in an empty list",
+                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(0));
+    }
+
+    /**
+     * A initializer that can produce circular dependency if AbstractFolderConfiguration is not properly initialized 
+     * on startup.
+     */
+    public static class TestInitialization {
+
+        @Initializer(before = InitMilestone.JOB_LOADED, after = InitMilestone.PLUGINS_STARTED)
+        @SuppressWarnings("unused")
+        public static void init(Jenkins jenkins) {
+            AbstractFolderConfiguration.get();
+        }
+
+        @Initializer(after = InitMilestone.PLUGINS_STARTED)
+        @SuppressWarnings("unused")
+        public static void init2(Jenkins jenkins) {
+            AbstractFolderConfiguration.get();
+        }
+    }
+}


### PR DESCRIPTION
See [JENKINS-60393](https://issues.jenkins-ci.org/browse/JENKINS-60393): the configuration of the defaults in the constructor of the GlobalConfiguration may cause the loading to fail on startup in some cases

### Proposed changelog entries

* Ensure all plugin are loaded before setting global defaults

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez @rsandell 