### PR TITLE
Add hasVisibleItems API

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -1010,6 +1010,19 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
     }
 
     /**
+     * Checks if folder has visible items
+     * @return true if folder has visible items false otherwise
+     */
+    public boolean hasVisibleItems() {
+        for (I item : items.values()) {
+            if (item.hasPermission(Item.READ)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

This adds an API to check if there are visible items.

See jenkinsci/branch-api-plugin#173 for potential use where this can improve performance for the downstream consumer by reducing number of `hasPermission` checks done to its bare minimum instead of checking against every item.

### Proposed changelog entries

* Developer: Add hasVisibleItems API


<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez

