### PR TITLE
Bump credentials plugin for bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <revision>6.12</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.130</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.11</version>
+      <version>2.2.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
We have a CI failure on a bom PR (https://github.com/jenkinsci/bom/pull/172) that seems to be caused by an old credentials plugin dep here

https://ci.jenkins.io/blue/organizations/jenkins/Tools%2Fbom/detail/PR-172/11/tests

Could we get a release for the bom too pretty please, this is our last failure on bumping jcasc in the bom