### PR TITLE
[JENKINS-60900] Fix enable/disable controls display

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -1230,7 +1230,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
      * @return {@code true} if and only if {@link #setDisabled(boolean)} is implemented
      * @since 6.1.0
      */
-    protected boolean supportsMakeDisabled() {
+    public boolean supportsMakeDisabled() {
         return false;
     }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -387,7 +387,7 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
      * {@inheritDoc}
      */
     @Override
-    protected boolean supportsMakeDisabled() {
+    public boolean supportsMakeDisabled() {
         return true;
 
     }

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
@@ -37,10 +37,6 @@ THE SOFTWARE.
       </div>
       <j:out value="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}"/>
   </div>
-  <!-- give actions a chance to contribute summary item -->
-  <j:forEach var="a" items="${it.allActions}">
-    <st:include page="summary" from="${a}" optional="true" it="${a}" />
-  </j:forEach>
   <this:description />
   <j:choose>
     <j:when test="${!it.supportsMakeDisabled()}">
@@ -66,4 +62,8 @@ THE SOFTWARE.
       </div>
     </j:otherwise>
   </j:choose>
+  <!-- give actions a chance to contribute summary item -->
+  <j:forEach var="a" items="${it.allActions}">
+    <st:include page="summary" from="${a}" optional="true" it="${a}" />
+  </j:forEach>
 </j:jelly>

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -74,7 +74,12 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -25,8 +25,12 @@ package com.cloudbees.hudson.plugins.folder.computed;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolderDescriptor;
 import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.config.AbstractFolderConfiguration;
+import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
 import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
 import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -73,12 +77,8 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
@@ -510,6 +510,23 @@ public class ComputedFolderTest {
         future.get();
         waitUntilNoActivityIgnoringThreadDeathUpTo(10000);
         d.checkRename("d2");
+    }
+    
+    @Issue("JENKINS-60900")
+    @Test
+    public void enabledAndDisableFromUi() throws Exception {
+        SampleComputedFolder folder = r.jenkins.createProject(SampleComputedFolder.class, "d");
+        assertFalse("by default, a folder is disabled", folder.isDisabled());
+        HtmlForm cfg = (HtmlForm)r.createWebClient().getPage(folder).getElementById("disable-project");
+        assertNotNull(cfg);
+        // Disable the folder
+        r.submit(cfg);
+        assertTrue(folder.isDisabled());
+        cfg = (HtmlForm)r.createWebClient().getPage(folder).getElementById("enable-project");
+        assertNotNull(cfg);
+        // Re enable the folder
+        r.submit(cfg);
+        assertFalse(folder.isDisabled());
     }
 
     /**

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -25,11 +25,8 @@ package com.cloudbees.hudson.plugins.folder.computed;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolderDescriptor;
 import com.cloudbees.hudson.plugins.folder.Folder;
-import com.cloudbees.hudson.plugins.folder.config.AbstractFolderConfiguration;
-import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
 import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
 import com.gargoylesoftware.htmlunit.html.DomElement;
-import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -78,7 +75,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;


### PR DESCRIPTION
See [JENKINS-60900](https://issues.jenkins-ci.org/browse/JENKINS-60900): The controls for the "Disable" feature are not displayed.

### Proposed changelog entries

* Display Enable / Disable buttons in a Folder's page if it supports it

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez