### PR TITLE
Bump core and parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.54</version>
+    <version>4.2</version>
     <relativePath />
   </parent>
 
@@ -21,9 +21,11 @@
   <properties>
     <revision>6.13</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.176.1</jenkins.version>
     <java.level>8</java.level>
     <no-test-jar>false</no-test-jar>
+    <configuration-as-code-plugin.version>1.36</configuration-as-code-plugin.version>
+    <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
   </properties>
   <licenses>
     <license>
@@ -52,11 +54,22 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.176.x</artifactId>
+        <version>9</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.2.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -68,26 +81,14 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>1.35</version>
+      <version>${configuration-as-code-plugin.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>1.35</version>
+      <version>${configuration-as-code-plugin.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <configuration>
-          <compatibleSinceVersion>5.2</compatibleSinceVersion>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
@@ -27,6 +27,7 @@ package com.cloudbees.hudson.plugins.folder.computed;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.jcraft.jzlib.GZIPInputStream;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.BulkChange;
 import hudson.Util;
@@ -343,6 +344,7 @@ public class FolderComputation<I extends TopLevelItem> extends Actionable implem
         return new AnnotatedLargeText<FolderComputation<I>>(eventsFile, Charsets.UTF_8, false, this);
     }
 
+    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED", justification = "Only one page is ever written here")
     public void writeLogTo(long offset, XMLOutput out) throws IOException {
         getLogText().writeHtmlTo(offset, out.asWriter());
     }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javax.servlet.ServletException;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
@@ -173,6 +174,8 @@ public class ComputedFolderTest {
         d.recompute(Result.SUCCESS);
         assertThat(d.getItem("A").scheduleBuild2(0), not(nullValue()));
         d.assertItemNames(3, "A", "B", "C");
+
+        r.waitUntilNoActivityUpTo((int) TimeUnit.MINUTES.toMillis(1));
     }
 
     @Issue("JENKINS-42680")


### PR DESCRIPTION
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

Will likely help with https://github.com/jenkinsci/bom/pull/225

We're getting failures on cloudbees-folder for some reason with PCT and updated jcasc =/ 

98% of users who updated to the last 2 releases will be able to use this minimum version:
http://stats.jenkins.io/pluginversions/cloudbees-folder.html

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez

