### PR TITLE
This tests are failing when running on the PCT

### DIFF
--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -417,7 +417,7 @@ public class FolderTest {
     @Issue("JENKINS-58282")
     @Test public void shouldHaveHealthMetricConfiguredGloballyOnCreation() throws Exception {
         assertThat("by default, global configuration should have all folder health metrics",
-                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(FolderHealthMetricDescriptor.all().size()));
+                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize((int) FolderHealthMetricDescriptor.all().stream().filter(d -> d.createDefault() != null).count()));
         
         Folder folder = r.jenkins.createProject(Folder.class, "myFolder");
         DescribableList<FolderHealthMetric, FolderHealthMetricDescriptor> healthMetrics = folder.getHealthMetrics();

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfigurationTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfigurationTest.java
@@ -47,7 +47,7 @@ public class AbstractFolderConfigurationTest {
     @Test
     public void shouldBeAbleToRemoveHealthMetricConfiguredGlobally() throws Exception {
         assertThat("by default, global configuration should have all folder health metrics",
-                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(FolderHealthMetricDescriptor.all().size()));
+                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize((int) FolderHealthMetricDescriptor.all().stream().filter(d -> d.createDefault() != null).count()));
 
         HtmlForm cfg = r.createWebClient().goTo("configure").getFormByName("config");
         for (HtmlElement element : cfg.getElementsByAttribute("div", "name", "healthMetrics")) {


### PR DESCRIPTION
1. `FolderTest.shouldHaveHealthMetricConfiguredGloballyOnCreation`: is checking [something](https://github.com/jenkinsci/cloudbees-folder-plugin/blob/2b9443b5c5d72030a92f59e8843c8948022830b5/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java#L420) which is not necessarily true (it depends on [this condition](https://github.com/jenkinsci/cloudbees-folder-plugin/blob/ae00f49fc0c6183983d67c799772fd8b9adc0840/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java#L50)). So I suspect there is a `FolderHealthMetricDescriptor` in the classpath (from some other plugin) which is returning `null` on `FolderHealthMetricDescriptor#createDefault` (which is fine).

2. `AbstractFolderConfigurationTest#shouldBeAbleToRemoveHealthMetricConfiguredGlobally`: same reason.

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez

