### PR TITLE
[JENKINS-62632] Process all children before raising exceptions

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/DeletingChildrenException.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/DeletingChildrenException.java
@@ -14,7 +14,7 @@ public class DeletingChildrenException extends RuntimeException {
 
     @Override
     public String getMessage() {
-        return "Impossible to delete some children when computing the folder: \n" +
-                String.join("\n", exceptions.stream().map(e -> e.getMessage()).collect(Collectors.toList()));
+        return "Impossible to delete some children when computing the folder: \n\t" +
+                String.join("\n\t", exceptions.stream().map(e -> e.getMessage()).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/DeletingChildrenException.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/DeletingChildrenException.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class DeletingChildrenException extends RuntimeException {
+public class DeletingChildrenException extends IOException {
 
     private List<IOException> exceptions;
 
@@ -13,8 +13,14 @@ public class DeletingChildrenException extends RuntimeException {
     }
 
     @Override
+    public synchronized Throwable getCause() {
+        // It's only created if it has exceptions
+        return this.exceptions.get(0);
+    }
+
+    @Override
     public String getMessage() {
-        return "Impossible to delete some children when computing the folder: \n\t" +
-                String.join("\n\t", exceptions.stream().map(e -> e.getMessage()).collect(Collectors.toList()));
+        return "Impossible to delete some children when computing the folder. The first errors are: \n\t" +
+                String.join("\n\t", exceptions.stream().limit(3).map(e -> e.getMessage()).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/DeletingChildrenException.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/DeletingChildrenException.java
@@ -1,0 +1,20 @@
+package com.cloudbees.hudson.plugins.folder.computed;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DeletingChildrenException extends RuntimeException {
+
+    private List<IOException> exceptions;
+
+    public DeletingChildrenException(List<IOException> exceptions) {
+        this.exceptions = exceptions;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Impossible to delete some children when computing the folder: \n" +
+                String.join("\n", exceptions.stream().map(e -> e.getMessage()).collect(Collectors.toList()));
+    }
+}


### PR DESCRIPTION
See [JENKINS-62632](https://issues.jenkins-ci.org/browse/JENKINS-62632).

### Proposed changelog entries

* Entry 1: Process and try to delete all children before actually raising the exceptions for those who could not be deleted.

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez

