### PR TITLE
use diamond operator, remove superflous throws and fixed some deprecation warnings

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/DefaultOrphanedItemStrategy.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/DefaultOrphanedItemStrategy.java
@@ -234,7 +234,7 @@ public class DefaultOrphanedItemStrategy extends OrphanedItemStrategy {
         if (pruneDeadBranches) {
             listener.getLogger().printf("Evaluating orphaned items in %s%n", owner.getFullDisplayName());
             List<I> candidates = new ArrayList<I>(orphaned);
-            Collections.sort(candidates, new Comparator<I>() {
+            candidates.sort(new Comparator<I>() {
                 @Override
                 public int compare(I i1, I i2) {
                     boolean disabled1 = disabled(i1);

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorRecTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorRecTest.java
@@ -31,7 +31,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.BulkChange;
 import hudson.Util;
-import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
@@ -43,7 +42,7 @@ import hudson.model.TopLevelItem;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,12 +63,12 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import org.kohsuke.stapler.StaplerRequest;
 
 import static com.cloudbees.hudson.plugins.folder.ChildNameGeneratorAltTest.windowsFFS;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests {@link ChildNameGenerator} using a generator where the previous implementation of the computed folder used a
@@ -87,7 +86,7 @@ public class ChildNameGeneratorRecTest {
      * Then: mangling gets applied
      */
     @Test
-    public void createdFromScratch() throws Exception {
+    public void createdFromScratch() {
         r.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -134,7 +133,7 @@ public class ChildNameGeneratorRecTest {
      */
     @Test
     @LocalData // to enable running on e.g. windows, keep the resource path short, so the test name must be short too
-    public void upgrade() throws Exception {
+    public void upgrade() {
         r.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -248,9 +247,9 @@ public class ChildNameGeneratorRecTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static class ComputedFolderImpl extends ComputedFolder<FreeStyleProject> {
 
-        private Set<String> fatalKids = new TreeSet<String>();
+        private Set<String> fatalKids = new TreeSet<>();
 
-        private List<String> kids = new ArrayList<String>();
+        private List<String> kids = new ArrayList<>();
         /**
          * The number of computations since either Jenkins was restarted or the folder was created.
          */
@@ -273,11 +272,11 @@ public class ChildNameGeneratorRecTest {
         }
 
         public List<String> getCreated() {
-            return created == null ? new ArrayList<String>() : created;
+            return created == null ? new ArrayList<>() : created;
         }
 
         public List<String> getDeleted() {
-            return deleted == null ? new ArrayList<String>() : deleted;
+            return deleted == null ? new ArrayList<>() : deleted;
         }
 
         public Set<String> getFatalKids() {
@@ -286,7 +285,7 @@ public class ChildNameGeneratorRecTest {
 
         public void setFatalKids(Set<String> fatalKids) {
             if (!this.fatalKids.equals(fatalKids)) {
-                this.fatalKids = new TreeSet<String>(fatalKids);
+                this.fatalKids = new TreeSet<>(fatalKids);
                 try {
                     save();
                 } catch (IOException e) {
@@ -305,7 +304,7 @@ public class ChildNameGeneratorRecTest {
 
         public void setKids(List<String> kids) {
             if (!this.kids.equals(kids)) {
-                this.kids = new ArrayList<String>(kids);
+                this.kids = new ArrayList<>(kids);
                 try {
                     save();
                 } catch (IOException e) {
@@ -340,7 +339,7 @@ public class ChildNameGeneratorRecTest {
         }
 
         public void addKids(String... kids) {
-            List<String> k = new ArrayList<String>(Arrays.asList(kids));
+            List<String> k = new ArrayList<>(Arrays.asList(kids));
             k.removeAll(this.kids);
             if (this.kids.addAll(k)) {
                 try {
@@ -365,8 +364,8 @@ public class ChildNameGeneratorRecTest {
         protected void computeChildren(ChildObserver<FreeStyleProject> observer, TaskListener listener) throws
                 IOException, InterruptedException {
             round++;
-            created = new ArrayList<String>();
-            deleted = new ArrayList<String>();
+            created = new ArrayList<>();
+            deleted = new ArrayList<>();
             listener.getLogger().println("=== Round #" + round + " ===");
             for (String kid : kids) {
                 if (fatalKids.contains(kid)) {
@@ -432,29 +431,29 @@ public class ChildNameGeneratorRecTest {
 
         public void assertItemNames(int round, String... names) {
             assertEquals(round, this.round);
-            TreeSet<String> actual = new TreeSet<String>();
+            TreeSet<String> actual = new TreeSet<>();
             for (FreeStyleProject p : getItems()) {
                 actual.add(p.getName());
             }
-            assertThat(actual, anyOf(is(new TreeSet<String>(Arrays.asList(names))), is(windowsFFS(names))));
+            assertThat(actual, anyOf(is(new TreeSet<>(Arrays.asList(names))), is(windowsFFS(names))));
         }
 
         public void assertItemShortUrls(int round, String... names) {
             assertEquals(round, this.round);
-            TreeSet<String> actual = new TreeSet<String>();
+            TreeSet<String> actual = new TreeSet<>();
             for (FreeStyleProject p : getItems()) {
                 actual.add(p.getShortUrl());
             }
-            assertThat(actual, is(new TreeSet<String>(Arrays.asList(names))));
+            assertThat(actual, is(new TreeSet<>(Arrays.asList(names))));
         }
 
         public void assertItemDirs(int round, String... names) {
             assertEquals(round, this.round);
-            TreeSet<String> actual = new TreeSet<String>();
+            TreeSet<String> actual = new TreeSet<>();
             for (FreeStyleProject p : getItems()) {
                 actual.add(p.getRootDir().getName());
             }
-            assertThat(actual, is(new TreeSet<String>(Arrays.asList(names))));
+            assertThat(actual, is(new TreeSet<>(Arrays.asList(names))));
         }
 
         @TestExtension
@@ -488,7 +487,7 @@ public class ChildNameGeneratorRecTest {
         }
 
         @Override
-        public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) throws Descriptor.FormException {
+        public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) {
             return this;
         }
 
@@ -560,11 +559,7 @@ public class ChildNameGeneratorRecTest {
     @NonNull
     public static String rawDecode(@NonNull String s) {
         final byte[] bytes; // should be US-ASCII but we can be tolerant
-        try {
-            bytes = s.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException("JLS specification mandates UTF-8 as a supported encoding", e);
-        }
+        bytes = s.getBytes(StandardCharsets.UTF_8);
         final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         for (int i = 0; i < bytes.length; i++) {
             final int b = bytes[i];
@@ -580,11 +575,7 @@ public class ChildNameGeneratorRecTest {
             }
             buffer.write(b);
         }
-        try {
-            return new String(buffer.toByteArray(), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException("JLS specification mandates UTF-8 as a supported encoding", e);
-        }
+        return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
     }
 
 

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ConfigurationAsCodeTest.java
@@ -8,10 +8,10 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 public class ConfigurationAsCodeTest extends RoundTripAbstractTest {
 

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -69,8 +69,17 @@ import jenkins.model.Jenkins;
 import jenkins.model.RenameAction;
 import jenkins.util.Timer;
 import org.acegisecurity.AccessDeniedException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -199,8 +208,8 @@ public class FolderTest {
             try {
                 // Access metadata from another thread.
                 whatRemainedWhenDeleted.put(item.getFullName(), Timer.get().submit(new Callable<Set<String>>() {
-                    @Override public Set<String> call() throws Exception {
-                        Set<String> remaining = new TreeSet<String>();
+                    @Override public Set<String> call() {
+                        Set<String> remaining = new TreeSet<>();
                         for (Item i : Jenkins.get().getAllItems()) {
                             remaining.add(i.getFullName());
                             if (i instanceof Actionable) {
@@ -374,8 +383,8 @@ public class FolderTest {
         r.jenkins.reload();
         
         // Add another property
-        Map<Permission,Set<String>> grantedPermissions = new HashMap<Permission, Set<String>>();
-        Set<String> sids = new HashSet<String>();
+        Map<Permission,Set<String>> grantedPermissions = new HashMap<>();
+        Set<String> sids = new HashSet<>();
         sids.add("admin");
         grantedPermissions.put(Jenkins.ADMINISTER, sids);
         folder = r.jenkins.getItemByFullName("myFolder", Folder.class);

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
@@ -34,8 +34,11 @@ import hudson.util.StreamTaskListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
@@ -83,7 +86,7 @@ public class ComputedFolder2Test {
         }
 
         @Override
-        protected void computeChildren(ChildObserver<FreeStyleProject> observer, TaskListener listener) throws IOException, InterruptedException {
+        protected void computeChildren(ChildObserver<FreeStyleProject> observer, TaskListener listener) throws InterruptedException {
             for (String kid : kids) {
                 FreeStyleProject p = observer.shouldUpdate(kid);
                 try {

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -75,13 +75,19 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -126,7 +132,7 @@ public class ComputedFolderTest {
         d.assertItemNames(5, "A", "B", "C", "D");
         assertEquals("[A, B, C, D, B]", d.created.toString());
         assertEquals("[B]", d.deleted.toString());
-        Map<String,String> descriptions = new TreeMap<String,String>();
+        Map<String,String> descriptions = new TreeMap<>();
         for (FreeStyleProject p : d.getItems()) {
             descriptions.put(p.getName(), p.getDescription());
         }
@@ -468,7 +474,7 @@ public class ComputedFolderTest {
         d.onKid("B");
         future.get();
         waitUntilNoActivityIgnoringThreadDeathUpTo(10000);
-        List<Throwable> deaths = new ArrayList<Throwable>();
+        List<Throwable> deaths = new ArrayList<>();
         for (Computer comp : r.jenkins.getComputers()) {
             for (Executor e : comp.getExecutors()) {
                 if (e.getCauseOfDeath() != null) {
@@ -567,8 +573,8 @@ public class ComputedFolderTest {
                 return;
 
             if (System.currentTimeMillis() - startTime > timeout) {
-                List<Queue.Executable> building = new ArrayList<Queue.Executable>();
-                List<Throwable> deaths = new ArrayList<Throwable>();
+                List<Queue.Executable> building = new ArrayList<>();
+                List<Throwable> deaths = new ArrayList<>();
                 for (Computer c : r.jenkins.getComputers()) {
                     for (Executor e : c.getExecutors()) {
                         if (e.isBusy()) {
@@ -626,10 +632,10 @@ public class ComputedFolderTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static class SampleComputedFolder extends ComputedFolder<FreeStyleProject> {
 
-        List<String> kids = new ArrayList<String>();
+        List<String> kids = new ArrayList<>();
         int round;
-        List<String> created = new ArrayList<String>();
-        List<String> deleted = new ArrayList<String>();
+        List<String> created = new ArrayList<>();
+        List<String> deleted = new ArrayList<>();
 
         private SampleComputedFolder(ItemGroup parent, String name) {
             super(parent, name);
@@ -684,11 +690,11 @@ public class ComputedFolderTest {
 
         void assertItemNames(int round, String... names) {
             assertEquals(round, this.round);
-            Set<String> actual = new TreeSet<String>();
+            Set<String> actual = new TreeSet<>();
             for (FreeStyleProject p : getItems()) {
                 actual.add(p.getName());
             }
-            assertEquals(new TreeSet<String>(Arrays.asList(names)).toString(), actual.toString());
+            assertEquals(new TreeSet<>(Arrays.asList(names)).toString(), actual.toString());
         }
 
         @TestExtension
@@ -938,10 +944,10 @@ public class ComputedFolderTest {
 
     public static class CoordinatedComputedFolder extends ComputedFolder<FreeStyleProject> {
 
-        List<String> kids = new ArrayList<String>();
+        List<String> kids = new ArrayList<>();
         int round;
-        List<String> created = new ArrayList<String>();
-        List<String> deleted = new ArrayList<String>();
+        List<String> created = new ArrayList<>();
+        List<String> deleted = new ArrayList<>();
         CountDownLatch compute = new CountDownLatch(2);
 
         private CoordinatedComputedFolder(ItemGroup parent, String name) {
@@ -1038,11 +1044,11 @@ public class ComputedFolderTest {
 
         void assertItemNames(int round, String... names) {
             assertEquals(round, this.round);
-            Set<String> actual = new TreeSet<String>();
+            Set<String> actual = new TreeSet<>();
             for (FreeStyleProject p : getItems()) {
                 actual.add(p.getName());
             }
-            assertEquals(new TreeSet<String>(Arrays.asList(names)).toString(), actual.toString());
+            assertEquals(new TreeSet<>(Arrays.asList(names)).toString(), actual.toString());
         }
 
         @TestExtension

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/EventOutputStreamsTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/EventOutputStreamsTest.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,8 +39,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class EventOutputStreamsTest {
@@ -107,9 +108,9 @@ public class EventOutputStreamsTest {
         t2.start();
         t1.join();
         t2.join();
-        List<String> as = new ArrayList<String>();
-        List<String> bs = new ArrayList<String>();
-        for (String line : FileUtils.readLines(file)) {
+        List<String> as = new ArrayList<>();
+        List<String> bs = new ArrayList<>();
+        for (String line : FileUtils.readLines(file, StandardCharsets.UTF_8)) {
             assertThat("Line does not have both thread output: '" + StringEscapeUtils.escapeJava(line)+"'",
                     line.matches("^\\d+[AB](\\d+[AB])+$"), is(false));
             assertThat("Line does not contain a null character: '" + StringEscapeUtils.escapeJava(line) + "'",
@@ -122,10 +123,10 @@ public class EventOutputStreamsTest {
                 fail("unexpected line: '" + StringEscapeUtils.escapeJava(line) +"'");
             }
         }
-        List<String> sorted = new ArrayList<String>(as);
+        List<String> sorted = new ArrayList<>(as);
         Collections.sort(sorted);
         assertThat(as, is(sorted));
-        sorted = new ArrayList<String>(bs);
+        sorted = new ArrayList<>(bs);
         Collections.sort(sorted);
         assertThat(bs, is(sorted));
     }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ThrottleComputationQueueTaskDispatcherTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ThrottleComputationQueueTaskDispatcherTest.java
@@ -22,11 +22,11 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class ThrottleComputationQueueTaskDispatcherTest {
     private static final Logger LOGGER = Logger.getLogger(ThrottleComputationQueueTaskDispatcherTest.class.getName());

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfigurationTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfigurationTest.java
@@ -16,9 +16,9 @@ import org.jvnet.hudson.test.LoggerRule;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 
 public class AbstractFolderConfigurationTest {
 

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProviderTest.java
@@ -62,10 +62,10 @@ import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockQueueItemAuthenticator;
 import org.jvnet.hudson.test.TestBuilder;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 public class FolderCredentialsProviderTest {
 
@@ -161,7 +161,7 @@ public class FolderCredentialsProviderTest {
         strategy.grant(Computer.BUILD).everywhere().to("bob");
 
         r.jenkins.setAuthorizationStrategy(strategy);
-        HashMap<String, Authentication> jobsToUsers = new HashMap<String, Authentication>();
+        HashMap<String, Authentication> jobsToUsers = new HashMap<>();
         jobsToUsers.put(prj.getFullName(), User.getOrCreateByIdOrFullName("bob").impersonate());
         MockQueueItemAuthenticator authenticator = new MockQueueItemAuthenticator(jobsToUsers);
 
@@ -188,7 +188,7 @@ public class FolderCredentialsProviderTest {
         strategy.grant(Computer.BUILD).everywhere().to("bob");
 
         r.jenkins.setAuthorizationStrategy(strategy);
-        HashMap<String, Authentication> jobsToUsers = new HashMap<String, Authentication>();
+        HashMap<String, Authentication> jobsToUsers = new HashMap<>();
         jobsToUsers.put(prj.getFullName(), User.getOrCreateByIdOrFullName("bob").impersonate());
         MockQueueItemAuthenticator authenticator = new MockQueueItemAuthenticator(jobsToUsers);
 
@@ -219,7 +219,7 @@ public class FolderCredentialsProviderTest {
         strategy.grant(Computer.BUILD).everywhere().to("bob");
 
         r.jenkins.setAuthorizationStrategy(strategy);
-        HashMap<String, Authentication> jobsToUsers = new HashMap<String, Authentication>();
+        HashMap<String, Authentication> jobsToUsers = new HashMap<>();
         jobsToUsers.put(prj.getFullName(), User.getOrCreateByIdOrFullName("bob").impersonate());
         MockQueueItemAuthenticator authenticator = new MockQueueItemAuthenticator(jobsToUsers);
 
@@ -262,7 +262,7 @@ public class FolderCredentialsProviderTest {
         strategy.grant(Computer.BUILD).everywhere().to("bob");
 
         r.jenkins.setAuthorizationStrategy(strategy);
-        HashMap<String, Authentication> jobsToUsers = new HashMap<String, Authentication>();
+        HashMap<String, Authentication> jobsToUsers = new HashMap<>();
         jobsToUsers.put(prj.getFullName(), User.getOrCreateByIdOrFullName("bob").impersonate());
         MockQueueItemAuthenticator authenticator = new MockQueueItemAuthenticator(jobsToUsers);
 
@@ -294,8 +294,7 @@ public class FolderCredentialsProviderTest {
         }
 
         @Override
-        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
-                throws InterruptedException, IOException {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
             IdCredentials credentials = CredentialsProvider.findCredentialById(id, IdCredentials.class, build);
             if (credentials == null) {
                 listener.getLogger().printf("Could not find any credentials with id %s%n", id);


### PR DESCRIPTION
* used diamond operator, 
* some try with resources
* remove superflous throws and 
* fixed some deprecation warnings (most of junit deprecation of assertThrows)

### Proposed changelog entries

* Internal: Refactorings

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez

