### PR TITLE
[JENKINS-63312] avoid unnecessary chaining of FolderComputations

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
@@ -107,9 +107,9 @@ public class FolderComputation<I extends TopLevelItem> extends Actionable implem
     @Nonnull
     private transient final ComputedFolder<I> folder;
 
-    /** The previous run, if any. */
+    /** The previous run result, if any. */
     @CheckForNull
-    private transient final FolderComputation<I> previous;
+    private transient final Result previousResult;
 
     /** The events output stream handler */
     @CheckForNull
@@ -132,7 +132,7 @@ public class FolderComputation<I extends TopLevelItem> extends Actionable implem
 
     protected FolderComputation(@Nonnull ComputedFolder<I> folder, @CheckForNull FolderComputation<I> previous) {
         this.folder = folder;
-        this.previous = previous;
+        this.previousResult = previous == null ? null : previous.getResult();
     }
 
     /**
@@ -448,7 +448,7 @@ public class FolderComputation<I extends TopLevelItem> extends Actionable implem
 
     @CheckForNull
     public Result getPreviousResult() {
-        return previous == null ? null : previous.result;
+        return previousResult;
     }
 
     @Nonnull


### PR DESCRIPTION
See [JENKINS-63312](https://issues.jenkins-ci.org/browse/JENKINS-63312).

### Proposed changelog entries

* Entry 1: Fix possible memory leak (`FolderComputation` chained to previous `FolderComputation`, etc.)

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests: *I can't think of a meaningful test for this change TBH...*

@fcojfernandez

