### PR TITLE
[JENKINS-63836] Not add heath metrics by default in the Global Configuration

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
@@ -23,6 +23,8 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
 
     private List<FolderHealthMetric> healthMetrics;
 
+    public static final boolean ADD_HEALTH_METRICS = Boolean.getBoolean(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
+
     @Nonnull
     public static AbstractFolderConfiguration get() {
         AbstractFolderConfiguration instance = GlobalConfiguration.all().get(AbstractFolderConfiguration.class);
@@ -40,22 +42,24 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
     /**
      * Auto-configure the default metrics after all plugins have been loaded.
      */
-    // Disabling autoConfigure as per JENKINS-58282 & JENKINS-63836
-    /*@Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
     public static void autoConfigure() {
-        AbstractFolderConfiguration abstractFolderConfiguration = AbstractFolderConfiguration.get();
-        if (abstractFolderConfiguration.healthMetrics == null) {
-            List<FolderHealthMetric> metrics = new ArrayList<>();
-            for (FolderHealthMetricDescriptor d : FolderHealthMetricDescriptor.all()) {
-                FolderHealthMetric metric = d.createDefault();
-                if (metric != null) {
-                    metrics.add(metric);
+        // Don't add health metrics by default in autoConfigure as per JENKINS-58282 & JENKINS-63836
+        if (ADD_HEALTH_METRICS) {
+            AbstractFolderConfiguration abstractFolderConfiguration = AbstractFolderConfiguration.get();
+            if (abstractFolderConfiguration.healthMetrics == null) {
+                List<FolderHealthMetric> metrics = new ArrayList<>();
+                for (FolderHealthMetricDescriptor d : FolderHealthMetricDescriptor.all()) {
+                    FolderHealthMetric metric = d.createDefault();
+                    if (metric != null) {
+                        metrics.add(metric);
+                    }
                 }
+                abstractFolderConfiguration.setHealthMetrics(new DescribableList<FolderHealthMetric,
+                        FolderHealthMetricDescriptor>(abstractFolderConfiguration, metrics));
             }
-            abstractFolderConfiguration.setHealthMetrics(new DescribableList<FolderHealthMetric,
-                    FolderHealthMetricDescriptor>(abstractFolderConfiguration, metrics));
         }
-    }*/
+    }
 
     @Nonnull
     public List<FolderHealthMetric> getHealthMetrics() {

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
@@ -40,7 +40,8 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
     /**
      * Auto-configure the default metrics after all plugins have been loaded.
      */
-    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
+    // Disabling autoConfigure as per JENKINS-58282 & JENKINS-63836
+    /*@Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
     public static void autoConfigure() {
         AbstractFolderConfiguration abstractFolderConfiguration = AbstractFolderConfiguration.get();
         if (abstractFolderConfiguration.healthMetrics == null) {
@@ -54,7 +55,7 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
             abstractFolderConfiguration.setHealthMetrics(new DescribableList<FolderHealthMetric,
                     FolderHealthMetricDescriptor>(abstractFolderConfiguration, metrics));
         }
-    }
+    }*/
 
     @Nonnull
     public List<FolderHealthMetric> getHealthMetrics() {

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
@@ -23,8 +23,6 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
 
     private List<FolderHealthMetric> healthMetrics;
 
-    public static final boolean ADD_HEALTH_METRICS = Boolean.getBoolean(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
-
     @Nonnull
     public static AbstractFolderConfiguration get() {
         AbstractFolderConfiguration instance = GlobalConfiguration.all().get(AbstractFolderConfiguration.class);
@@ -32,6 +30,10 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
             throw new IllegalStateException();
         }
         return instance;
+    }
+
+    private static boolean getHealthMetricsProperty() {
+        return Boolean.getBoolean(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
     }
 
     @DataBoundConstructor
@@ -45,7 +47,7 @@ public class AbstractFolderConfiguration extends GlobalConfiguration {
     @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
     public static void autoConfigure() {
         // Don't add health metrics by default in autoConfigure as per JENKINS-58282 & JENKINS-63836
-        if (ADD_HEALTH_METRICS) {
+        if (getHealthMetricsProperty()) {
             AbstractFolderConfiguration abstractFolderConfiguration = AbstractFolderConfiguration.get();
             if (abstractFolderConfiguration.healthMetrics == null) {
                 List<FolderHealthMetric> metrics = new ArrayList<>();

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
@@ -45,7 +45,7 @@ public class FolderSystemPropertyTest {
     public JenkinsRule j = new JenkinsRule();
 
     @BeforeClass
-    public static void enableHealhMetrics() {
+    public static void enableHealthMetrics() {
         System.setProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS", "true");
     }
 

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
@@ -51,7 +51,7 @@ public class FolderSystemPropertyTest {
 
     @AfterClass
     public static void disableHealthMetrics() {
-        System.setProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS", null);
+        System.clearProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
     }
 
     @Issue("JENKINS-63836")

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
@@ -44,14 +44,22 @@ public class FolderSystemPropertyTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
+    private static String HEALTH_METRIC_PROPERTY;
+
     @BeforeClass
     public static void enableHealthMetrics() {
+        HEALTH_METRIC_PROPERTY = System.getProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
         System.setProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS", "true");
     }
 
     @AfterClass
     public static void disableHealthMetrics() {
-        System.clearProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
+        // Put back the previous value before the test was executed
+        if (HEALTH_METRIC_PROPERTY != null) {
+            System.setProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS", HEALTH_METRIC_PROPERTY);
+        } else {
+            System.clearProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
+        }
     }
 
     @Issue("JENKINS-63836")

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
@@ -51,7 +51,7 @@ public class FolderSystemPropertyTest {
 
     @AfterClass
     public static void disableHealthMetrics() {
-        System.clearProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
+        System.setProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS", null);
     }
 
     @Issue("JENKINS-63836")
@@ -70,7 +70,6 @@ public class FolderSystemPropertyTest {
         healthMetrics = folder.getHealthMetrics();
         assertThat("a new created folder should have all the folder health metrics configured globally",
                 healthMetrics, iterableWithSize(0));
-        System.clearProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
     }
 
 }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderSystemPropertyTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.hudson.plugins.folder;
+
+import com.cloudbees.hudson.plugins.folder.config.AbstractFolderConfiguration;
+import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric;
+import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
+import hudson.util.DescribableList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class FolderSystemPropertyTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @BeforeClass
+    public static void enableHealhMetrics() {
+        System.setProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS", "true");
+    }
+
+    @AfterClass
+    public static void disableHealthMetrics() {
+        System.clearProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
+    }
+
+    @Issue("JENKINS-63836")
+    @Test
+    public void shouldHaveHealthMetricConfiguredGloballyOnSystemProperty() throws Exception {
+        assertThat("if used .ADD_HEALTH_METRICS system property, global configuration should have all folder health metrics",
+                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize((int) FolderHealthMetricDescriptor.all().stream().filter(d -> d.createDefault() != null).count()));
+
+        Folder folder = j.jenkins.createProject(Folder.class, "myFolder");
+        DescribableList<FolderHealthMetric, FolderHealthMetricDescriptor> healthMetrics = folder.getHealthMetrics();
+        assertThat("a new created folder should have all the folder health metrics configured globally",
+                healthMetrics.toList(), containsInAnyOrder(AbstractFolderConfiguration.get().getHealthMetrics().toArray()));
+
+        AbstractFolderConfiguration.get().setHealthMetrics(null);
+        folder = j.jenkins.createProject(Folder.class, "myFolder2");
+        healthMetrics = folder.getHealthMetrics();
+        assertThat("a new created folder should have all the folder health metrics configured globally",
+                healthMetrics, iterableWithSize(0));
+        System.clearProperty(AbstractFolderConfiguration.class.getName() + ".ADD_HEALTH_METRICS");
+    }
+
+}

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -425,19 +425,19 @@ public class FolderTest {
 
     @Issue("JENKINS-58282")
     @Test public void shouldHaveHealthMetricConfiguredGloballyOnCreation() throws Exception {
-        assertThat("by default, global configuration should have all folder health metrics",
-                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize((int) FolderHealthMetricDescriptor.all().stream().filter(d -> d.createDefault() != null).count()));
+        assertThat("by default, global configuration should not have any health metrics",
+                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(0));
         
         Folder folder = r.jenkins.createProject(Folder.class, "myFolder");
         DescribableList<FolderHealthMetric, FolderHealthMetricDescriptor> healthMetrics = folder.getHealthMetrics();
-        assertThat("a new created folder should have all the folder health metrics configured globally",
-                healthMetrics.toList(), containsInAnyOrder(AbstractFolderConfiguration.get().getHealthMetrics().toArray()));
+        assertThat("a new created folder should not have any health metrics configured globally",
+                healthMetrics, hasSize(0));
 
         AbstractFolderConfiguration.get().setHealthMetrics(null);
         folder = r.jenkins.createProject(Folder.class, "myFolder2");
         healthMetrics = folder.getHealthMetrics();
-        assertThat("a new created folder should have all the folder health metrics configured globally",
-                healthMetrics, iterableWithSize(0));
+        assertThat("a new created folder should not have any health metrics configured globally",
+                healthMetrics, hasSize(0));
     }
 
     @Test public void visibleItems() throws IOException, InterruptedException {

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -423,7 +423,7 @@ public class FolderTest {
         anchor.click();
     }
 
-    @Issue("JENKINS-58282")
+    @Issue("JENKINS-63836")
     @Test public void shouldNotHaveHealthMetricConfiguredGloballyOnCreation() throws Exception {
         assertThat("by default, global configuration should not have any health metrics",
                 AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(0));

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -424,7 +424,7 @@ public class FolderTest {
     }
 
     @Issue("JENKINS-58282")
-    @Test public void shouldHaveHealthMetricConfiguredGloballyOnCreation() throws Exception {
+    @Test public void shouldNotHaveHealthMetricConfiguredGloballyOnCreation() throws Exception {
         assertThat("by default, global configuration should not have any health metrics",
                 AbstractFolderConfiguration.get().getHealthMetrics(), hasSize(0));
         

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfigurationTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfigurationTest.java
@@ -60,10 +60,6 @@ public class AbstractFolderConfigurationTest {
         List<FolderHealthMetric> healthMetrics = new ArrayList<>(1);
         healthMetrics.add(new WorstChildHealthMetric(true));
         AbstractFolderConfiguration.get().setHealthMetrics(healthMetrics);
-
-        assertThat("by default, global configuration should not have any folder health metrics",
-                AbstractFolderConfiguration.get().getHealthMetrics(), hasSize((int) FolderHealthMetricDescriptor.all().stream().filter(d -> d.createDefault() != null).count()));
-
         HtmlForm cfg = r.createWebClient().goTo("configure").getFormByName("config");
         for (HtmlElement element : cfg.getElementsByAttribute("div", "name", "healthMetrics")) {
             element.remove();


### PR DESCRIPTION

See [JENKINS-63836](https://issues.jenkins-ci.org/browse/JENKINS-63836).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* [JENKINS-63836](https://issues.jenkins-ci.org/browse/JENKINS-63836) : Not add heath metrics by default in the Global Configuration

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez

