### PR TITLE
document sample value for interval

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger/help-interval.html
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger/help-interval.html
@@ -22,6 +22,8 @@
  ~ THE SOFTWARE.
  -->
 <div>
-    The maximum amount of time since the last indexing that is allowed to elapse before an indexing is triggered.
-    For example: interval('5m') // or '2h', '7d', '5000ms', '60s'
+    <p>
+        The maximum amount of time since the last indexing that is allowed to elapse before an indexing is triggered.
+        For example: interval('5m') // or '2h', '7d', '5000ms', '60s'
+    </p>
 </div>

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger/help-interval.html
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger/help-interval.html
@@ -23,4 +23,5 @@
  -->
 <div>
     The maximum amount of time since the last indexing that is allowed to elapse before an indexing is triggered.
+    For example: interval('5m') // or '2h', '7d', '5000ms', '60s'
 </div>


### PR DESCRIPTION
See [JENKINS-55429](https://issues.jenkins-ci.org/browse/JENKINS-55429).  Having recently run into this same issue, I took the step requested by Daniel Spilker and created this PR against the Folder plugin to improve the documentation around the expected value for `interval`.

### Proposed changelog entries

* Document sample value for `periodicFolderTrigger / interval`


### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez

