### PR TITLE
Use Java 7 versions of GZIPInputStream and GZIPOutputStream

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
@@ -25,7 +25,7 @@
 package com.cloudbees.hudson.plugins.folder.computed;
 
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
-import com.jcraft.jzlib.GZIPInputStream;
+import java.util.zip.GZIPInputStream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;


### PR DESCRIPTION
See jenkinsci/docker-build-step-plugin#75. [JZlib](https://github.com/ymnk/jzlib) has not been updated since 2013. Since then, [`GZIPInputStream`](https://docs.oracle.com/javase/8/docs/api/java/util/zip/GZIPInputStream.html) and [`GZIPOutputStream`](https://docs.oracle.com/javase/8/docs/api/java/util/zip/GZIPOutputStream.html) have been added to the Java 7 API, so it seems more prudent to use those implementations.

CC @fcojfernandez