### PR TITLE
Fix roundrip of the `disabled` field on folders

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -1361,7 +1361,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
             icon.setOwner(this);
 
             submit(req, rsp);
-            makeDisabled(json.optBoolean("disable"));
+            makeDisabled(json.optBoolean("disabled"));
 
             save();
             bc.commit();

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -54,7 +54,7 @@ THE SOFTWARE.
         </f:entry>
 
         <j:if test="${it.supportsMakeDisabled()}">
-          <f:entry title="${%Disable}" field="disable">
+          <f:entry title="${%Disable}" field="disabled">
             <f:checkbox title="${%blurb(it.pronoun)}"/>
           </f:entry>
         </j:if>

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -184,6 +184,14 @@ public class ComputedFolderTest {
         r.waitUntilNoActivityUpTo((int) TimeUnit.MINUTES.toMillis(1));
     }
 
+    @Test
+    public void roundTrip() throws Exception {
+        SampleComputedFolder d = r.jenkins.createProject(SampleComputedFolder.class, "d");
+        d.makeDisabled(true);
+        d = r.configRoundtrip(d);
+        assertTrue(d.isDisabled());
+    }
+
     @Issue("JENKINS-42680")
     @Test
     public void foldersAsChildren() throws Exception {


### PR DESCRIPTION
I noticed this problem on an organization folder, but I assume the problem is the same with any folder that can be disabled.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fix roundtrip of `disabled` field for folders

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests

@fcojfernandez

