### PR TITLE
Extend startup notification timeout as jobs continue to be loaded

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -601,7 +601,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
     }
 
     private static void onExtendTimeout(long timeout, @NonNull TimeUnit unit) {
-        // TODO When baseline is updated to jenkinsci/jenkins#6237, use Jenkins.get().getLifecycle().onExtendTimeout(timeout, unit)
+        // TODO When baseline is updated to Jenkins 2.335 jenkinsci/jenkins#6237, use Jenkins.get().getLifecycle().onExtendTimeout(timeout, unit)
         Method onExtendTimeout;
         try {
             onExtendTimeout = Lifecycle.class.getMethod("onExtendTimeout", long.class, TimeUnit.class);

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -570,8 +570,8 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
                     float percentage = 100.0f * jobEncountered.incrementAndGet() / Math.max(1, jobTotal.get());
                     long now = System.currentTimeMillis();
                     if (loadingTick == 0) {
-                        // Buy ourselves a tick interval to complete the first tick.
-                        onExtendTimeout(TICK_INTERVAL, TimeUnit.MILLISECONDS);
+                        // Buy ourselves two tick intervals to complete the first tick + some slop.
+                        onExtendTimeout(2 * TICK_INTERVAL, TimeUnit.MILLISECONDS);
 
                         loadingTick = now;
                     } else if (now - loadingTick > TICK_INTERVAL) {


### PR DESCRIPTION
**Untested** PR to consume the new API introduced in jenkinsci/jenkins#6237 to keep pushing back the startup timeout as long as Jenkins is continuing to make progress in loading jobs. This should make it far less likely that people will hit the `systemd` service startup timeout when using `systemd` with `Type=notify`.