### PR TITLE
[JENKINS-67753] Use "notbuilt" icon instead of grey to display the build status

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
@@ -460,7 +460,7 @@ public class FolderComputation<I extends TopLevelItem> extends Actionable implem
         }
         Result previousResult = getPreviousResult();
         if (previousResult == null) {
-            return isBuilding() ? BallColor.GREY_ANIME : BallColor.GREY;
+            return isBuilding() ? BallColor.NOTBUILT_ANIME : BallColor.NOTBUILT;
         }
         return isBuilding() ? previousResult.color.anime() : previousResult.color;
     }


### PR DESCRIPTION
See [JENKINS-67753](https://issues.jenkins.io/browse/JENKINS-67753).

The change proposed exchanges the icon for unbuild items from "grey" to "notbuilt" allowing newer Jenkins versions to override it properly and display the modernized "notbuilt" sprite if available, and a grey ball on older versions:

![](https://i.imgur.com/mC9HaOs.png)

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [X] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)