### PR TITLE
[JENKINS-67921] Add a shutdown hook stopping all ongoing folder computations

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -1126,7 +1126,7 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
     public static class StopComputationsOnShutdown extends ItemListener {
         @Override
         public void onBeforeShutdown() {
-            for (ComputedFolder cf : Jenkins.get().getAllItems(ComputedFolder.class)) {
+            for (ComputedFolder cf : Jenkins.get().allItems(ComputedFolder.class)) {
                 try {
                     cf.getComputation().doStop();
                 } catch (IOException | ServletException e) {

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
@@ -77,6 +77,7 @@ public class ComputedFolder2Test {
         });
     }
 
+    @Issue("JENKINS-67921")
     @Test
     public void computationAbortedOnShutdown() {
         rr.then(r -> {
@@ -157,10 +158,10 @@ public class ComputedFolder2Test {
         @Override
         protected void computeChildren(ChildObserver<FreeStyleProject> observer, TaskListener listener) throws InterruptedException {
             // Just sleep long enough
-            Thread.sleep(1000000);
+            Thread.sleep(Long.MAX_VALUE);
         }
 
-        @TestExtension
+        @TestExtension("computationAbortedOnShutdown")
         public static final class DescriptorImpl extends AbstractFolderDescriptor {
             @Override
             public TopLevelItem newInstance(ItemGroup parent, String name) {


### PR DESCRIPTION
When running JenkinsRule based tests on windows, there are often locks on indexing.log
which is the file holding the computation logs.

This means a folder computation is running while Jenkins is being
shutdown, and this computation is not aborted before shutting down.

See [JENKINS-67921](https://issues.jenkins-ci.org/browse/JENKINS-67921).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Shutdown ongoing folder computations when shutting down Jenkins
* ...

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
