### PR TITLE
Do not serialize `CountDownLatch`

### DIFF
--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -1143,7 +1143,7 @@ public class ComputedFolderTest {
         int round;
         List<String> created = new ArrayList<>();
         List<String> deleted = new ArrayList<>();
-        CountDownLatch compute = new CountDownLatch(2);
+        transient CountDownLatch compute = new CountDownLatch(2);
 
         private CoordinatedComputedFolder(ItemGroup parent, String name) {
             super(parent, name);


### PR DESCRIPTION
Found when running `mvn clean verify -Dtest=com.cloudbees.hudson.plugins.folder.computed.ComputedFolderTest -Djenkins-test-harness.version=1721.v385389722736 '-DargLine=--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED'` on Java 17 as in jenkinsci/bom#935. The problem is that the test is trying to serialize a latch, which is not a realistic production use case. This PR  makes the latch transient so XStream doesn't try to serialize it. The test doesn't need to restart Jenkins, so it doesn't need this field to be serialized. And this gets the test to pass on Java 17.

```
java.io.IOException: java.lang.RuntimeException: Failed to serialize com.cloudbees.hudson.plugins.folder.computed.ComputedFolderTest$CoordinatedComputedFolder#compute for class com.cloudbees.hudson.plugins.folder.computed.ComputedFolderTest$CoordinatedComputedFolder
	at hudson.XmlFile.write(XmlFile.java:220)
	at hudson.model.AbstractItem.save(AbstractItem.java:617)
	at com.cloudbees.hudson.plugins.folder.AbstractFolder.save(AbstractFolder.java:1313)
	at hudson.model.ItemGroupMixIn.createProject(ItemGroupMixIn.java:322)
	at jenkins.model.Jenkins.createProject(Jenkins.java:3122)
	at jenkins.model.Jenkins.createProject(Jenkins.java:3117)
	at jenkins.model.Jenkins.createProject(Jenkins.java:3153)
	at com.cloudbees.hudson.plugins.folder.computed.ComputedFolderTest.concurrentEvents(ComputedFolderTest.java:582)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:606)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.RuntimeException: Failed to serialize com.cloudbees.hudson.plugins.folder.computed.ComputedFolderTest$CoordinatedComputedFolder#compute for class com.cloudbees.hudson.plugins.folder.computed.ComputedFolderTest$CoordinatedComputedFolder
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:274)
	at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:241)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:174)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:226)
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:163)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:59)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:44)
	at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:83)
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1266)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1255)
	at com.thoughtworks.xstream.XStream.toXML(XStream.java:1228)
	at hudson.XmlFile.write(XmlFile.java:213)
	... 20 more
Caused by: java.lang.RuntimeException: Failed to serialize java.util.concurrent.CountDownLatch#sync for class java.util.concurrent.CountDownLatch
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:274)
	at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:241)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:174)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:226)
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:163)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:59)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
	at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:283)
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:270)
	... 33 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private static final long java.util.concurrent.locks.AbstractOwnableSynchronizer.serialVersionUID accessible: module java.base does not "opens java.util.concurrent.locks" to unnamed module @25bbe1b6
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.buildDictionaryEntryForClass(FieldDictionary.java:176)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.buildMap(FieldDictionary.java:142)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.fieldsFor(FieldDictionary.java:80)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:167)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:206)
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:163)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:59)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
	at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:283)
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:270)
	... 42 more
```