### PR TITLE
Icon for folder credentials store is gone from credentials plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- remember to change the io.jenkins.tools.bom artifact when changing this -->
-    <jenkins.version>2.346.1</jenkins.version>
+    <jenkins.version>2.346</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- remember to change the io.jenkins.tools.bom artifact when changing this -->
-    <jenkins.version>2.346</jenkins.version>
+    <jenkins.version>2.319.1</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
   </properties>
@@ -57,8 +57,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.346.x</artifactId>
-        <version>1409.v7659b_c072f18</version>
+        <artifactId>bom-2.319.x</artifactId>
+        <version>1210.vcd41f6657f03</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- remember to change the io.jenkins.tools.bom artifact when changing this -->
-    <jenkins.version>2.277.1</jenkins.version>
+    <jenkins.version>2.346.1</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
   </properties>
@@ -57,8 +57,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.277.x</artifactId>
-        <version>984.vb5eaac999a7e</version>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1409.v7659b_c072f18</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
@@ -388,6 +388,10 @@ public class Folder extends AbstractFolder<TopLevelItem> implements DirectlyModi
             IconSet.icons.addIcon(new Icon("icon-folder-disabled icon-md", "plugin/cloudbees-folder/images/svgs/folder-disabled.svg", Icon.ICON_MEDIUM_STYLE));
             IconSet.icons.addIcon(new Icon("icon-folder-disabled icon-lg", "plugin/cloudbees-folder/images/svgs/folder-disabled.svg", Icon.ICON_LARGE_STYLE));
             IconSet.icons.addIcon(new Icon("icon-folder-disabled icon-xlg", "plugin/cloudbees-folder/images/svgs/folder-disabled.svg", Icon.ICON_XLARGE_STYLE));
+            IconSet.icons.addIcon(new Icon("icon-folder-store icon-sm", "plugin/cloudbees-folder/images/svgs/folder-store.svg", Icon.ICON_SMALL_STYLE));
+            IconSet.icons.addIcon(new Icon("icon-folder-store icon-md", "plugin/cloudbees-folder/images/svgs/folder-store.svg", Icon.ICON_MEDIUM_STYLE));
+            IconSet.icons.addIcon(new Icon("icon-folder-store icon-lg", "plugin/cloudbees-folder/images/svgs/folder-store.svg", Icon.ICON_LARGE_STYLE));
+            IconSet.icons.addIcon(new Icon("icon-folder-store icon-xlg", "plugin/cloudbees-folder/images/svgs/folder-store.svg", Icon.ICON_XLARGE_STYLE));
         }
     }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
@@ -579,7 +579,7 @@ public class FolderCredentialsProvider extends CredentialsProvider {
             @Override
             public String getIconFileName() {
                 return isVisible()
-                        ? "/plugin/credentials/images/folder-store.svg"
+                        ? "/plugin/cloudbees-folder/images/svgs/folder-store.svg"
                         : null;
             }
 
@@ -589,7 +589,7 @@ public class FolderCredentialsProvider extends CredentialsProvider {
             @Override
             public String getIconClassName() {
                 return isVisible()
-                        ? "icon-credentials-folder-store"
+                        ? "icon-folder-store"
                         : null;
             }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
@@ -579,7 +579,7 @@ public class FolderCredentialsProvider extends CredentialsProvider {
             @Override
             public String getIconFileName() {
                 return isVisible()
-                        ? "/plugin/credentials/images/48x48/folder-store.png"
+                        ? "/plugin/credentials/images/folder-store.svg"
                         : null;
             }
 

--- a/src/main/webapp/images/svgs/folder-store.svg
+++ b/src/main/webapp/images/svgs/folder-store.svg
@@ -1,0 +1,1389 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="90"
+   inkscape:export-xdpi="90"
+   sodipodi:docname="folder-store.svg"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:version="0.32"
+   id="svg249"
+   height="48.000000px"
+   width="48.000000px"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient8624">
+      <stop
+         id="stop8626"
+         offset="0"
+         style="stop-color:#cc0000;stop-opacity:0.56862748;" />
+      <stop
+         style="stop-color:#cc0000;stop-opacity:0.72156864;"
+         offset="0.11"
+         id="stop8628" />
+      <stop
+         id="stop8630"
+         offset="1"
+         style="stop-color:#cc0000;stop-opacity:0.23137255;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8598">
+      <stop
+         id="stop8600"
+         offset="0"
+         style="stop-color:#73d216;stop-opacity:0.56862748;" />
+      <stop
+         style="stop-color:#73d216;stop-opacity:0.72156864;"
+         offset="0.11"
+         id="stop8602" />
+      <stop
+         id="stop8604"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:0.23137255;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8554">
+      <stop
+         id="stop8556"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:0.56862748;" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0.72156864;"
+         offset="0.11"
+         id="stop8558" />
+      <stop
+         id="stop8560"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:0.23137255;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="0"
+         id="stop5050" />
+      <stop
+         id="stop5056"
+         offset="0.5"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15662">
+      <stop
+         id="stop15664"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop15666"
+         offset="1.0000000"
+         style="stop-color:#f8f8f8;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <radialGradient
+       id="aigrd3"
+       cx="20.8921"
+       cy="64.5679"
+       r="5.257"
+       fx="20.8921"
+       fy="64.5679"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15573" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         id="stop15575" />
+    </radialGradient>
+    <radialGradient
+       id="aigrd2"
+       cx="20.8921"
+       cy="114.5684"
+       r="5.256"
+       fx="20.8921"
+       fy="114.5684"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15566" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         id="stop15568" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient269">
+      <stop
+         id="stop270"
+         offset="0.0000000"
+         style="stop-color:#a3a3a3;stop-opacity:1.0000000;" />
+      <stop
+         id="stop271"
+         offset="1.0000000"
+         style="stop-color:#4c4c4c;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient259">
+      <stop
+         id="stop260"
+         offset="0.0000000"
+         style="stop-color:#fafafa;stop-opacity:1.0000000;" />
+      <stop
+         id="stop261"
+         offset="1.0000000"
+         style="stop-color:#bbbbbb;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2119">
+      <stop
+         style="stop-color:#d2b32a;stop-opacity:0.56730771;"
+         offset="0.0000000"
+         id="stop2121" />
+      <stop
+         id="stop2378"
+         offset="0.11000000"
+         style="stop-color:#ffeb3f;stop-opacity:0.72156864;" />
+      <stop
+         style="stop-color:#fff493;stop-opacity:0.23076923;"
+         offset="1.0000000"
+         id="stop2123" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2119"
+       id="linearGradient7465"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,81.398788,-22.432431)"
+       x1="333.57144"
+       y1="459.00504"
+       x2="564.28572"
+       y2="459.00504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2119"
+       id="linearGradient7467"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,81.398788,-22.432431)"
+       x1="336.15625"
+       y1="504.34375"
+       x2="567.00000"
+       y2="504.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8624"
+       id="linearGradient8640"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-46.363212,17.578864)"
+       x1="333.57144"
+       y1="459.00504"
+       x2="564.28571"
+       y2="459.00504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8624"
+       id="linearGradient8642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-46.363212,17.578864)"
+       x1="336.15625"
+       y1="504.34375"
+       x2="567"
+       y2="504.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8554"
+       id="linearGradient8644"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-1.423616,-0.065427)"
+       x1="333.57144"
+       y1="459.00504"
+       x2="564.28571"
+       y2="459.00504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8554"
+       id="linearGradient8646"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-1.423616,-0.065427)"
+       x1="336.15625"
+       y1="504.34375"
+       x2="567"
+       y2="504.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8598"
+       id="linearGradient8648"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-30.238212,6.828864)"
+       x1="333.57144"
+       y1="459.00504"
+       x2="564.28571"
+       y2="459.00504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8598"
+       id="linearGradient8650"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-30.238212,6.828864)"
+       x1="336.15625"
+       y1="504.34375"
+       x2="567"
+       y2="504.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2846"
+       id="linearGradient2852"
+       x1="27.366341"
+       y1="26.580296"
+       x2="31.335964"
+       y2="30.557772"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4477"
+       id="radialGradient2842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.237968,0,28.93278)"
+       cx="24.130018"
+       cy="37.967922"
+       fx="24.130018"
+       fy="37.967922"
+       r="16.528622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2366"
+       id="linearGradient2372"
+       x1="18.292673"
+       y1="13.602121"
+       x2="17.500893"
+       y2="25.743469"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.237968,0,28.93278)"
+       r="16.528622"
+       fy="37.967922"
+       fx="24.130018"
+       cy="37.967922"
+       cx="24.130018"
+       id="radialGradient4493"
+       xlink:href="#linearGradient4487"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.592963,0,0,2.252104,-25.05975,-18.941)"
+       r="6.6562500"
+       fy="13.078408"
+       fx="15.414371"
+       cy="13.078408"
+       cx="15.414371"
+       id="radialGradient4473"
+       xlink:href="#linearGradient4467"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="8.3085051"
+       fy="21.817987"
+       fx="18.240929"
+       cy="21.817987"
+       cx="18.240929"
+       id="radialGradient4460"
+       xlink:href="#linearGradient4454"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.334593,0,0,1.291292,-6.973842,-7.460658)"
+       gradientUnits="userSpaceOnUse"
+       y2="31.062500"
+       x2="33.218750"
+       y1="34.000000"
+       x1="30.656250"
+       id="linearGradient4446"
+       xlink:href="#linearGradient4440"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4440">
+      <stop
+         id="stop4442"
+         offset="0"
+         style="stop-color:#7d7d7d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#b1b1b1;stop-opacity:1.0000000;"
+         offset="0.50000000"
+         id="stop4448" />
+      <stop
+         id="stop4444"
+         offset="1.0000000"
+         style="stop-color:#686868;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4454">
+      <stop
+         id="stop4456"
+         offset="0.0000000"
+         style="stop-color:#729fcf;stop-opacity:0.20784314;" />
+      <stop
+         id="stop4458"
+         offset="1.0000000"
+         style="stop-color:#729fcf;stop-opacity:0.67619050;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4467">
+      <stop
+         id="stop4469"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4471"
+         offset="1.0000000"
+         style="stop-color:#ffffff;stop-opacity:0.24761905;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4477"
+       inkscape:collect="always">
+      <stop
+         id="stop4479"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4481"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4487"
+       inkscape:collect="always">
+      <stop
+         id="stop4489"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4491"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2366">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2368" />
+      <stop
+         id="stop2374"
+         offset="0.50000000"
+         style="stop-color:#ffffff;stop-opacity:0.21904762;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2370" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2846">
+      <stop
+         style="stop-color:#8a8a8a;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2848" />
+      <stop
+         style="stop-color:#484848;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2850" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective47"
+       inkscape:persp3d-origin="24 : 16 : 1"
+       inkscape:vp_z="48 : 24 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 24 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4477"
+       id="radialGradient16111"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.237968,0,28.93278)"
+       cx="24.130018"
+       cy="37.967922"
+       fx="24.130018"
+       fy="37.967922"
+       r="16.528622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2846"
+       id="linearGradient16113"
+       gradientUnits="userSpaceOnUse"
+       x1="27.366341"
+       y1="26.580296"
+       x2="31.335964"
+       y2="30.557772" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4440"
+       id="linearGradient16115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.334593,0,0,1.291292,-6.973842,-7.460658)"
+       x1="30.656250"
+       y1="34.000000"
+       x2="33.218750"
+       y2="31.062500" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2366"
+       id="linearGradient16117"
+       gradientUnits="userSpaceOnUse"
+       x1="18.292673"
+       y1="13.602121"
+       x2="17.500893"
+       y2="25.743469" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4487"
+       id="radialGradient16119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.237968,0,28.93278)"
+       cx="24.130018"
+       cy="37.967922"
+       fx="24.130018"
+       fy="37.967922"
+       r="16.528622" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4454"
+       id="radialGradient16121"
+       gradientUnits="userSpaceOnUse"
+       cx="18.240929"
+       cy="21.817987"
+       fx="18.240929"
+       fy="21.817987"
+       r="8.3085051" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4467"
+       id="radialGradient16123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.592963,0,0,2.252104,-25.05975,-18.941)"
+       cx="15.414371"
+       cy="13.078408"
+       fx="15.414371"
+       fy="13.078408"
+       r="6.6562500" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4467"
+       id="radialGradient16126"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.592963,0,0,2.252104,-15.421344,38.511625)"
+       cx="15.414371"
+       cy="13.078408"
+       fx="15.414371"
+       fy="13.078408"
+       r="6.6562500" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4440"
+       id="linearGradient16133"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.334593,0,0,1.291292,2.6645639,49.991967)"
+       x1="30.656250"
+       y1="34.000000"
+       x2="33.218750"
+       y2="31.062500" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2846"
+       id="linearGradient16137"
+       gradientUnits="userSpaceOnUse"
+       x1="27.366341"
+       y1="26.580296"
+       x2="31.335964"
+       y2="30.557772"
+       gradientTransform="translate(9.6384059,57.452625)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4477"
+       id="radialGradient16140"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.237968,0,28.93278)"
+       cx="24.130018"
+       cy="37.967922"
+       fx="24.130018"
+       fy="37.967922"
+       r="16.528622" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2846"
+       id="linearGradient16154"
+       x1="4.4455142"
+       y1="18.920233"
+       x2="30.556271"
+       y2="18.920233"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2366"
+       id="linearGradient16156"
+       gradientUnits="userSpaceOnUse"
+       x1="18.292673"
+       y1="13.602121"
+       x2="17.500893"
+       y2="25.743469" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2846"
+       id="linearGradient16163"
+       gradientUnits="userSpaceOnUse"
+       x1="4.4455142"
+       y1="18.920233"
+       x2="30.556271"
+       y2="18.920233" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2366"
+       id="linearGradient16165"
+       gradientUnits="userSpaceOnUse"
+       x1="18.292673"
+       y1="13.602121"
+       x2="17.500893"
+       y2="25.743469" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2846"
+       id="linearGradient16198"
+       gradientUnits="userSpaceOnUse"
+       x1="4.4455142"
+       y1="18.920233"
+       x2="30.556271"
+       y2="18.920233" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2366"
+       id="linearGradient16200"
+       gradientUnits="userSpaceOnUse"
+       x1="18.292673"
+       y1="13.602121"
+       x2="17.500893"
+       y2="25.743469" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16203">
+      <rect
+         style="fill:#cc0000;fill-opacity:1;stroke:#dcdcdc;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect16205"
+         width="51.024128"
+         height="17.599627"
+         x="-29.51263"
+         y="63.224758"
+         transform="matrix(0.99199712,-0.1262605,0.1262605,0.99199712,0,0)" />
+    </clipPath>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.000000,0.000000,0.000000,0.242494,1.565588e-16,31.50606)"
+       r="19.136078"
+       fy="41.591846"
+       fx="24.35099"
+       cy="41.591846"
+       cx="24.35099"
+       id="radialGradient9812"
+       xlink:href="#linearGradient9806"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="32.050499"
+       x2="22.065331"
+       y1="36.987999"
+       x1="22.175976"
+       id="linearGradient9772"
+       xlink:href="#linearGradient9766"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3096"
+       id="linearGradient3104"
+       x1="18.112709"
+       y1="31.367750"
+       x2="15.514889"
+       y2="6.1802502"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient319"
+       id="linearGradient322"
+       gradientTransform="matrix(1.317489,0,0,0.816256,-0.879573,-1.318166)"
+       x1="13.035696"
+       y1="32.567184"
+       x2="12.853771"
+       y2="46.689312"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       y2="66.834053"
+       x2="9.8980894"
+       y1="13.773066"
+       x1="6.2297964"
+       gradientTransform="matrix(1.516844,0,0,0.708978,-0.879573,-1.318166)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient491"
+       xlink:href="#linearGradient3983"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3983">
+      <stop
+         id="stop3984"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:0.87628865;" />
+      <stop
+         id="stop3985"
+         offset="1.0000000"
+         style="stop-color:#fffffe;stop-opacity:0.0000000;" />
+    </linearGradient>
+    <radialGradient
+       r="30.905205"
+       fy="37.517986"
+       fx="20.706017"
+       cy="37.517986"
+       cx="20.706017"
+       gradientTransform="matrix(1.055022,-0.02734504,0.177703,1.190929,-3.572177,-7.125301)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient238"
+       xlink:href="#linearGradient1789"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient1789">
+      <stop
+         id="stop1790"
+         offset="0.0000000"
+         style="stop-color:#202020;stop-opacity:1.0000000;" />
+      <stop
+         id="stop1791"
+         offset="1.0000000"
+         style="stop-color:#b9b9b9;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient319">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop320" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop321" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3096">
+      <stop
+         style="stop-color:#424242;stop-opacity:1;"
+         offset="0"
+         id="stop3098" />
+      <stop
+         style="stop-color:#777777;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop3100" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9766">
+      <stop
+         id="stop9768"
+         offset="0"
+         style="stop-color:#6194cb;stop-opacity:1;" />
+      <stop
+         id="stop9770"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9806"
+       inkscape:collect="always">
+      <stop
+         id="stop9808"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop9810"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6715"
+       xlink:href="#linearGradient5048-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5048-8">
+      <stop
+         id="stop5050-8"
+         offset="0"
+         style="stop-color:black;stop-opacity:0;" />
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0.5"
+         id="stop5056-9" />
+      <stop
+         id="stop5052-2"
+         offset="1"
+         style="stop-color:black;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6717"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5060"
+       inkscape:collect="always">
+      <stop
+         id="stop5062"
+         offset="0"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         id="stop5064"
+         offset="1"
+         style="stop-color:black;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6719"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective68"
+       inkscape:persp3d-origin="24 : 16 : 1"
+       inkscape:vp_z="48 : 24 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 24 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2846"
+       id="linearGradient19107"
+       gradientUnits="userSpaceOnUse"
+       x1="4.4455142"
+       y1="18.920233"
+       x2="30.556271"
+       y2="18.920233" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2366"
+       id="linearGradient19109"
+       gradientUnits="userSpaceOnUse"
+       x1="18.292673"
+       y1="13.602121"
+       x2="17.500893"
+       y2="25.743469" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8624"
+       id="linearGradient19111"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-46.363212,17.578864)"
+       x1="333.57144"
+       y1="459.00504"
+       x2="564.28571"
+       y2="459.00504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8624"
+       id="linearGradient19113"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-46.363212,17.578864)"
+       x1="336.15625"
+       y1="504.34375"
+       x2="567"
+       y2="504.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2119"
+       id="linearGradient19115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,81.398788,-22.432431)"
+       x1="333.57144"
+       y1="459.00504"
+       x2="564.28572"
+       y2="459.00504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2119"
+       id="linearGradient19117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,81.398788,-22.432431)"
+       x1="336.15625"
+       y1="504.34375"
+       x2="567.00000"
+       y2="504.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8598"
+       id="linearGradient19119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-30.238212,6.828864)"
+       x1="333.57144"
+       y1="459.00504"
+       x2="564.28571"
+       y2="459.00504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8598"
+       id="linearGradient19121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-30.238212,6.828864)"
+       x1="336.15625"
+       y1="504.34375"
+       x2="567"
+       y2="504.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8554"
+       id="linearGradient19123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-1.423616,-0.065427)"
+       x1="333.57144"
+       y1="459.00504"
+       x2="564.28571"
+       y2="459.00504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8554"
+       id="linearGradient19125"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04585646,0.049308,-0.05215187,0.04891569,-1.423616,-0.065427)"
+       x1="336.15625"
+       y1="504.34375"
+       x2="567"
+       y2="504.34375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2846"
+       id="linearGradient19127"
+       gradientUnits="userSpaceOnUse"
+       x1="4.4455142"
+       y1="18.920233"
+       x2="30.556271"
+       y2="18.920233" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2366"
+       id="linearGradient19129"
+       gradientUnits="userSpaceOnUse"
+       x1="18.292673"
+       y1="13.602121"
+       x2="17.500893"
+       y2="25.743469" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-y="32"
+     inkscape:window-x="-5"
+     inkscape:window-height="867"
+     inkscape:window-width="999"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     showgrid="false"
+     inkscape:current-layer="layer5"
+     inkscape:cy="18.316284"
+     inkscape:cx="11.353703"
+     inkscape:zoom="10.30389"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="0.25490196"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:showpageshadow="false"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>text</rdf:li>
+            <rdf:li>plaintext</rdf:li>
+            <rdf:li>regular</rdf:li>
+            <rdf:li>document</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source>http://jimmac.musichall.cz</dc:source>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="Shadow" />
+  <g
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="Base"
+     id="layer1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="Text"
+     style="display:inline">
+    <g
+       id="g7334"
+       transform="translate(68.820186,-7.756368)" />
+    <g
+       style="display:inline"
+       id="g7336"
+       transform="translate(68.820186,-7.756368)" />
+    <g
+       id="g3678"
+       transform="translate(0.73900891,-0.14878731)"
+       style="opacity:0.5">
+      <g
+         inkscape:label="Folder"
+         id="layer1-6">
+        <g
+           id="g6707"
+           transform="matrix(0.02262383,0,0,0.02086758,43.38343,36.36962)"
+           style="display:inline">
+          <rect
+             y="-150.69685"
+             x="-1559.2523"
+             height="478.35718"
+             width="1339.6335"
+             id="rect6709"
+             style="opacity:0.40206185000000000;color:#000000;fill:url(#linearGradient6715);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+          <path
+             sodipodi:nodetypes="cccc"
+             id="path6711"
+             d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+             style="opacity:0.40206185000000000;color:#000000;fill:url(#radialGradient6717);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+             inkscape:connector-curvature="0" />
+          <path
+             style="opacity:0.40206185000000000;color:#000000;fill:url(#radialGradient6719);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+             d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+             id="path6713"
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           sodipodi:nodetypes="ccccccssssccc"
+           style="fill:url(#radialGradient238);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3104);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           id="path216"
+           d="m 4.5217805,38.687417 c 0.021796,0.416304 0.4599049,0.832609 0.8762095,0.832609 l 31.327021,0 c 0.416302,0 0.810812,-0.416305 0.789016,-0.832609 L 36.577584,11.460682 c -0.0218,-0.416303 -0.459897,-0.832616 -0.876201,-0.832616 l -13.270873,0 c -0.485057,0 -1.234473,-0.315589 -1.401644,-1.1066322 L 20.417475,6.6283628 C 20.262006,5.8926895 19.535261,5.5904766 19.118957,5.5904766 l -14.7788595,0 c -0.4163128,0 -0.8108208,0.4163041 -0.7890249,0.8326083 L 4.5217805,38.687417 z"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           d="m 5.2265927,22.5625 30.2655803,0"
+           id="path9788"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           d="m 5.0421736,18.5625 30.4469304,0"
+           id="path9784"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path9778"
+           d="m 4.9806965,12.5625 30.5073605,0"
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path9798"
+           d="m 5.3861577,32.5625 30.1087233,0"
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           d="m 5.5091398,34.5625 29.9877532,0"
+           id="path9800"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path9782"
+           d="m 5.0421736,16.5625 30.4469304,0"
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           d="m 5.0114345,14.5625 30.4771455,0"
+           id="path9780"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           d="m 4.9220969,10.5625 15.2808151,0"
+           id="path9776"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path9774"
+           d="m 4.8737534,8.5624999 14.7837336,0"
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999981999999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path9794"
+           d="m 5.3246666,28.5625 30.1692094,0"
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           d="m 5.2880638,26.5625 30.2051202,0"
+           id="path9792"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path9790"
+           d="m 5.2265927,24.5625 30.2655803,0"
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path9786"
+           d="m 5.1958537,20.5625 30.2957953,0"
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000011999999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000036000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           d="m 5.3246666,30.5625 30.1692094,0"
+           id="path9796"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cc"
+           id="path9802"
+           d="m 5.5091398,36.5625 29.9877532,0"
+           style="opacity:0.11363632999999999;color:#000000;fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="cccccccccscccccc"
+           id="path219"
+           d="m 6.068343,38.864023 c 0.016343,0.312228 -0.1809113,0.520379 -0.4985848,0.416303 l 0,0 C 5.2520766,39.176251 5.033027,38.968099 5.0166756,38.65587 L 4.068956,6.5913839 C 4.0526131,6.2791558 4.2341418,6.0906134 4.5463699,6.0906134 L 18.96842,6.0429196 c 0.312228,0 0.931943,0.3004727 1.132936,1.3221818 l 0.573489,2.8155346 C 20.247791,9.715379 20.255652,9.7010175 20.037287,9.0239299 L 19.631192,7.7647478 C 19.412142,7.0371009 18.932991,6.9328477 18.620763,6.9328477 l -12.8877741,0 c -0.3122276,0 -0.5094814,0.2081522 -0.4931306,0.5203887 L 6.1778636,38.968099 6.068343,38.864023 z"
+           style="opacity:0.45142858000000002;color:#000000;fill:url(#linearGradient491);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.21380496000000004;marker:none;visibility:visible;display:block;overflow:visible"
+           inkscape:connector-curvature="0" />
+        <g
+           inkscape:export-ydpi="74.800003"
+           inkscape:export-xdpi="74.800003"
+           transform="matrix(1.040764,0,0.05449252,1.040764,-8.670199,2.670594)"
+           id="g220"
+           style="fill:#ffffff;fill-opacity:0.75706213000000000;fill-rule:nonzero;stroke:none">
+          <path
+             sodipodi:nodetypes="cscscs"
+             id="path221"
+             d="m 42.417183,8.5151772 c 0.0051,-0.097113 -0.128161,-0.2469882 -0.235117,-0.2470056 l -13.031401,-0.00212 c 0,0 0.911714,0.5879545 2.201812,0.5962436 l 11.053497,0.07102 c 0.01109,-0.2117278 0.0027,-0.2560322 0.01121,-0.4181395 z"
+             style="fill:#ffffff;fill-opacity:0.50847461000000005"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           inkscape:export-ydpi="74.800003"
+           inkscape:export-xdpi="74.800003"
+           sodipodi:nodetypes="cscccscc"
+           id="path233"
+           d="m 39.783532,39.51062 c 1.143894,-0.04406 1.963076,-1.096299 2.047035,-2.321005 0.791787,-11.548687 1.65936,-21.231949 1.65936,-21.231949 0.07215,-0.247484 -0.167911,-0.494967 -0.48014,-0.494967 l -34.3711566,0 c 0,0 -1.8503191,21.866892 -1.8503191,21.866892 -0.1145551,0.982066 -0.4660075,1.804718 -1.5498358,2.183713 l 34.5450565,-0.0027 z"
+           style="color:#000000;fill:url(#linearGradient9772);fill-opacity:1;fill-rule:nonzero;stroke:#3465a4;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:0.46590911000000002;fill:none;stroke:url(#linearGradient322);stroke-width:0.99999970000000005px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 9.6202444,16.463921 32.7910986,0.06481 -1.574046,20.001979 c -0.08432,1.071511 -0.450678,1.428215 -1.872656,1.428215 -1.871502,0 -28.677968,-0.03241 -31.394742,-0.03241 0.2335983,-0.320811 0.3337557,-0.988623 0.3350963,-1.004612 L 9.6202444,16.463921 z"
+           id="path304"
+           sodipodi:nodetypes="ccsscsc"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:#ffffff;fill-opacity:0.08928570000000000;fill-rule:evenodd;stroke:none"
+           d="M 9.6202481,16.223182 8.4536014,31.866453 c 0,0 8.2961546,-4.148078 18.6663476,-4.148078 10.370193,0 15.55529,-11.495193 15.55529,-11.495193 l -33.0549909,0 z"
+           id="path323"
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         inkscape:label="pattern"
+         id="layer2" />
+    </g>
+    <g
+       id="g19069"
+       transform="matrix(0.64,0,0,0.64,17.160645,17.195486)">
+      <g
+         transform="matrix(0.8,0,0,0.8,25.035669,-32.664465)"
+         id="g16158">
+        <path
+           transform="matrix(1.245743,0,0,1.245743,-33.78694,35.275592)"
+           d="m 28.549437,18.920233 c 0,6.101942 -4.946602,11.048544 -11.048544,11.048544 -6.101943,0 -11.0485443,-4.946602 -11.0485443,-11.048544 0,-6.101943 4.9466013,-11.0485442 11.0485443,-11.0485442 6.101942,0 11.048544,4.9466012 11.048544,11.0485442 z"
+           sodipodi:ry="11.048544"
+           sodipodi:rx="11.048544"
+           sodipodi:cy="18.920233"
+           sodipodi:cx="17.500893"
+           id="path16146"
+           style="color:#000000;fill:none;stroke:url(#linearGradient19107);stroke-width:6.27135754;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:type="arc"
+           style="color:#000000;fill:none;stroke:#dcdcdc;stroke-width:3.76281476;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           id="path16144"
+           sodipodi:cx="17.500893"
+           sodipodi:cy="18.920233"
+           sodipodi:rx="11.048544"
+           sodipodi:ry="11.048544"
+           d="m 28.549437,18.920233 c 0,6.101942 -4.946602,11.048544 -11.048544,11.048544 -6.101943,0 -11.0485443,-4.946602 -11.0485443,-11.048544 0,-6.101943 4.9466013,-11.0485442 11.0485443,-11.0485442 6.101942,0 11.048544,4.9466012 11.048544,11.0485442 z"
+           transform="matrix(1.245743,0,0,1.245743,-33.78694,35.275592)" />
+        <path
+           transform="matrix(1.245743,0,0,1.245743,-33.78694,35.275592)"
+           d="m 28.549437,18.920233 c 0,6.101942 -4.946602,11.048544 -11.048544,11.048544 -6.101943,0 -11.0485443,-4.946602 -11.0485443,-11.048544 0,-6.101943 4.9466013,-11.0485442 11.0485443,-11.0485442 6.101942,0 11.048544,4.9466012 11.048544,11.0485442 z"
+           sodipodi:ry="11.048544"
+           sodipodi:rx="11.048544"
+           sodipodi:cy="18.920233"
+           sodipodi:cx="17.500893"
+           id="path4450"
+           style="color:#000000;fill:none;stroke:url(#linearGradient19109);stroke-width:1.25427127;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           sodipodi:type="arc" />
+      </g>
+      <g
+         transform="matrix(0,1,-1,0,80.994072,76.610493)"
+         id="g8632">
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csscccccccccccscccccccccccccc"
+           id="path8572"
+           d="m -55.007282,47.842831 c -2.639759,-2.83845 -7.175026,-2.882088 -10.136059,-0.104795 -2.961035,2.777293 -3.227032,7.324265 -0.587274,10.162715 1.980301,2.129354 5.028327,2.687439 7.680143,1.661762 l 0.834359,0.897161 1.996216,0.647276 -0.466555,0.997519 3.676179,3.519779 1.256755,-0.214473 -0.236983,1.311002 0.880714,0.947004 1.687014,-0.618032 -0.352822,1.419654 0.803458,0.863933 c 0.0061,0.0065 0.0069,0.0162 0.01545,0.01661 0.0086,4.18e-4 0.02508,0.0076 0.032,0.0011 0,0 3.133754,0.171346 3.133754,0.171346 0,2e-6 1.268467,-2.434012 1.268467,-2.434012 L -53.828449,55.540264 c 1.143411,-2.565748 0.775216,-5.596308 -1.178833,-7.697433 z m -5.242156,1.05967 0.200864,0.215983 c 0.528984,0.568799 0.479487,1.478864 -0.101125,2.023448 l -1.704481,1.598713 c -0.580613,0.544584 -1.471531,0.516579 -2.000514,-0.05222 l -0.200866,-0.215984 c -0.528983,-0.568798 -0.496036,-1.463343 0.08458,-2.007927 l 1.704479,-1.598712 c 0.580614,-0.544585 1.488082,-0.532101 2.017065,0.0367 z"
+           style="fill:#ef2929;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc"
+           id="path8574"
+           d="m -54.420325,55.975171 10.36962,11.484735 c 0.01216,0.01308 0.01308,0.03193 0.0021,0.04227 l -0.524128,0.491605 c -0.01102,0.01034 -0.02969,0.0081 -0.04185,-0.0049 l -10.36966,-11.484784 c -0.01216,-0.01308 -0.01308,-0.03193 -0.0021,-0.04227 l 0.52413,-0.491604 c 0.01102,-0.01034 0.02969,-0.0081 0.04185,0.0049 z"
+           style="fill:url(#linearGradient19111);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccscc"
+           id="path8576"
+           d="M -45.770336,69.367611 -56.36183,58.028131 c -0.01069,-0.0115 -0.04435,0.0041 -0.0773,0.035 l -1.497736,1.404798 0.829622,0.892069 1.991607,0.64208 -0.463922,1.000589 3.663605,3.519387 1.277455,-0.21441 -0.255716,1.313054 0.878439,0.944556 1.694669,-0.605735 -0.360019,1.410884 0.813952,0.875218 c 0.0061,0.0065 0.01369,0.01042 0.02228,0.01084 0.0086,4.17e-4 0.01817,-0.0026 0.02509,-0.0091 0,0 1.124579,0.06612 2.049463,0.120267 z"
+           style="fill:url(#linearGradient19113);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8578"
+           d="m -53.929456,54.724752 c -2.446216,-2.266344 -4.273881,-1.79471 -7.392629,-2.505413 l -0.554227,0.519835 c -0.589259,0.552694 -1.493444,0.524272 -2.030303,-0.053 l -0.203857,-0.219199 c -0.335279,-0.360516 -0.389945,-0.831147 -0.281329,-1.283038 -0.763302,-0.385167 -1.381718,-0.832369 -1.971191,-1.308085 -1.31757,2.508353 -1.036612,5.613844 0.923124,7.721088 2.502038,2.690365 6.804061,2.741762 9.603878,0.115683 0.910888,-0.854365 1.543571,-1.890113 1.906534,-2.987873 z"
+           style="opacity:0.45405405;fill:#cc0000;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8580"
+           d="m -60.261971,48.903164 0.204392,0.219777 c 0.528984,0.568799 0.48742,1.465133 -0.09319,2.009716 l -1.704844,1.599053 c -0.580613,0.544583 -1.473898,0.52509 -2.00288,-0.04371 l -0.204393,-0.219777 c -0.528984,-0.568799 -0.487419,-1.465133 0.09319,-2.009717 l 1.704843,-1.599052 c 0.580612,-0.544585 1.473896,-0.52509 2.00288,0.04371 z"
+           style="fill:none;stroke:#ac8b0b;stroke-width:1.13857627;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csscccccccccccscccccccccccccc"
+           style="fill:none;stroke:#a40000;stroke-width:1.5625;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m -55.007282,47.842831 c -2.639759,-2.83845 -7.175026,-2.882088 -10.136059,-0.104795 -2.961035,2.777293 -3.227032,7.324265 -0.587274,10.162715 1.980301,2.129354 5.028327,2.687439 7.680143,1.661762 l 0.834359,0.897161 2.260991,0.398932 -0.484113,1.51169 3.181742,2.988125 2.298296,-0.693679 -0.784086,2.321861 0.633496,0.681178 1.951788,-0.866375 -0.370378,1.933823 0.55624,0.598107 c 0.0061,0.0065 0.0069,0.0162 0.01545,0.01661 0.0086,4.18e-4 0.02508,0.0076 0.032,0.0011 0,0 3.133754,0.171346 3.133754,0.171346 0,2e-6 1.268467,-2.434012 1.268467,-2.434012 L -53.828449,55.540264 c 1.143411,-2.565748 0.775216,-5.596308 -1.178833,-7.697433 z m -5.242156,1.05967 0.200864,0.215983 c 0.528984,0.568799 0.479487,1.478864 -0.101125,2.023448 l -1.704481,1.598713 c -0.580613,0.544584 -1.471531,0.516579 -2.000514,-0.05222 l -0.200866,-0.215984 c -0.528983,-0.568798 -0.496036,-1.463343 0.08458,-2.007927 l 1.704479,-1.598712 c 0.580614,-0.544585 1.488082,-0.532101 2.017065,0.0367 z"
+           id="path8582" />
+      </g>
+      <g
+         transform="translate(-39.390793,5.063703)"
+         id="g7345">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#dabf3c;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="M 72.754718,7.8315357 C 70.114959,4.9930856 65.579692,4.9494479 62.618659,7.7267408 59.657624,10.504034 59.391627,15.051006 62.031385,17.889456 c 1.980301,2.129354 5.028327,2.687439 7.680143,1.661762 l 0.834359,0.897161 1.996216,0.647276 -0.466555,0.997519 3.676179,3.519779 1.256755,-0.214473 -0.236983,1.311002 0.880714,0.947004 1.687014,-0.618032 -0.352822,1.419654 0.803458,0.863933 c 0.0061,0.0065 0.0069,0.0162 0.01545,0.01661 0.0086,4.18e-4 0.02508,0.0076 0.032,0.0011 0,0 3.133754,0.171346 3.133754,0.171346 0,2e-6 1.268467,-2.434012 1.268467,-2.434012 L 73.933551,15.528969 c 1.143411,-2.565748 0.775216,-5.596308 -1.178833,-7.6974333 z m -5.242156,1.0596703 0.200864,0.2159831 c 0.528984,0.5687986 0.479487,1.4788639 -0.101125,2.0234479 L 65.90782,12.72935 c -0.580613,0.544584 -1.471531,0.516579 -2.000514,-0.05222 L 63.70644,12.461146 c -0.528983,-0.568798 -0.496036,-1.463343 0.08458,-2.007927 l 1.704479,-1.5987123 c 0.580614,-0.5445842 1.488082,-0.5321002 2.017065,0.036699 z"
+           id="path2100"
+           sodipodi:nodetypes="csscccccccccccscccccccccccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:url(#linearGradient19115);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m 73.341675,15.963876 10.36962,11.484735 c 0.01216,0.01308 0.01308,0.03193 0.0021,0.04227 l -0.524128,0.491605 c -0.01102,0.01034 -0.02969,0.0081 -0.04185,-0.0049 L 72.777757,16.492802 c -0.01216,-0.01308 -0.01308,-0.03193 -0.0021,-0.04227 l 0.52413,-0.491604 c 0.01102,-0.01034 0.02969,-0.0081 0.04185,0.0049 z"
+           id="path2102"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:url(#linearGradient19117);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="M 81.991664,29.356316 71.40017,18.016836 c -0.01069,-0.0115 -0.04435,0.0041 -0.0773,0.035 l -1.497736,1.404798 0.829622,0.892069 1.991607,0.64208 -0.463922,1.000589 3.663605,3.519387 1.277455,-0.21441 -0.255716,1.313054 0.878439,0.944556 1.694669,-0.605735 -0.360019,1.410884 0.813952,0.875218 c 0.0061,0.0065 0.01369,0.01042 0.02228,0.01084 0.0086,4.17e-4 0.01817,-0.0026 0.02509,-0.0091 0,0 1.124579,0.06612 2.049463,0.120267 z"
+           id="path2104"
+           sodipodi:nodetypes="ccccccccccccccscc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:0.45405405;fill:#c4a00f;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m 73.832544,14.713457 c -2.446216,-2.266344 -4.273881,-1.79471 -7.392629,-2.505413 l -0.554227,0.519835 c -0.589259,0.552694 -1.493444,0.524272 -2.030303,-0.053 L 63.651528,12.45568 c -0.335279,-0.360516 -0.389945,-0.831147 -0.281329,-1.283038 -0.763302,-0.385167 -1.381718,-0.832369 -1.971191,-1.3080854 -1.31757,2.5083534 -1.036612,5.6138444 0.923124,7.7210884 2.502038,2.690365 6.804061,2.741762 9.603878,0.115683 0.910888,-0.854365 1.543571,-1.890113 1.906534,-2.987873 z"
+           id="path2108" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#ac8b0b;stroke-width:1.13857627;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 67.500029,8.8918687 0.204392,0.2197769 c 0.528984,0.5687996 0.48742,1.4651334 -0.09319,2.0097164 l -1.704844,1.599053 c -0.580613,0.544583 -1.473898,0.52509 -2.00288,-0.04371 l -0.204393,-0.219777 c -0.528984,-0.568799 -0.487419,-1.465133 0.09319,-2.009717 l 1.704843,-1.5990523 c 0.580612,-0.5445844 1.473896,-0.5250896 2.00288,0.043709 z"
+           id="path2110" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path2112"
+           d="M 72.754718,7.8315357 C 70.114959,4.9930856 65.579692,4.9494479 62.618659,7.7267408 59.657624,10.504034 59.391627,15.051006 62.031385,17.889456 c 1.980301,2.129354 5.028327,2.687439 7.680143,1.661762 l 0.834359,0.897161 2.260991,0.398932 -0.484113,1.51169 3.181742,2.988125 2.298296,-0.693679 -0.784086,2.321861 0.633496,0.681178 1.951788,-0.866375 -0.370378,1.933823 0.55624,0.598107 c 0.0061,0.0065 0.0069,0.0162 0.01545,0.01661 0.0086,4.18e-4 0.02508,0.0076 0.032,0.0011 0,0 3.133754,0.171346 3.133754,0.171346 0,2e-6 1.268467,-2.434012 1.268467,-2.434012 L 73.933551,15.528969 c 1.143411,-2.565748 0.775216,-5.596308 -1.178833,-7.6974333 z m -5.242156,1.0596703 0.200864,0.2159831 c 0.528984,0.5687986 0.479487,1.4788639 -0.101125,2.0234479 L 65.90782,12.72935 c -0.580613,0.544584 -1.471531,0.516579 -2.000514,-0.05222 L 63.70644,12.461146 c -0.528983,-0.568798 -0.496036,-1.463343 0.08458,-2.007927 l 1.704479,-1.5987123 c 0.580614,-0.5445842 1.488082,-0.5321002 2.017065,0.036699 z"
+           style="fill:none;stroke:#ac8b0b;stroke-width:1.5625;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:nodetypes="csscccccccccccscccccccccccccc" />
+      </g>
+      <g
+         transform="matrix(0.5,0.86602541,-0.86602541,0.5,84.638813,37.536818)"
+         id="g8606">
+        <path
+           style="fill:#8ae234;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m -38.882282,37.092831 c -2.639759,-2.83845 -7.175026,-2.882088 -10.136059,-0.104795 -2.961035,2.777293 -3.227032,7.324265 -0.587274,10.162715 1.980301,2.129354 5.028327,2.687439 7.680143,1.661762 l 0.834359,0.897161 1.996216,0.647276 -0.466555,0.997519 3.676179,3.519779 1.256755,-0.214473 -0.236983,1.311002 0.880714,0.947004 1.687014,-0.618032 -0.352822,1.419654 0.803458,0.863933 c 0.0061,0.0065 0.0069,0.0162 0.01545,0.01661 0.0086,4.18e-4 0.02508,0.0076 0.032,0.0011 0,0 3.133754,0.171346 3.133754,0.171346 0,2e-6 1.268467,-2.434012 1.268467,-2.434012 L -37.703449,44.790264 c 1.143411,-2.565748 0.775216,-5.596308 -1.178833,-7.697433 z m -5.242156,1.05967 0.200864,0.215983 c 0.528984,0.568799 0.479487,1.478864 -0.101125,2.023448 l -1.704481,1.598713 c -0.580613,0.544584 -1.471531,0.516579 -2.000514,-0.05222 l -0.200866,-0.215984 c -0.528983,-0.568798 -0.496036,-1.463343 0.08458,-2.007927 l 1.704479,-1.598712 c 0.580614,-0.544584 1.488082,-0.532101 2.017065,0.0367 z"
+           id="path7760"
+           sodipodi:nodetypes="csscccccccccccscccccccccccccc"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:url(#linearGradient19119);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m -38.295325,45.225171 10.36962,11.484735 c 0.01216,0.01308 0.01308,0.03193 0.0021,0.04227 l -0.524128,0.491605 c -0.01102,0.01034 -0.02969,0.0081 -0.04185,-0.0049 l -10.36966,-11.484784 c -0.01216,-0.01308 -0.01308,-0.03193 -0.0021,-0.04227 l 0.52413,-0.491604 c 0.01102,-0.01034 0.02969,-0.0081 0.04185,0.0049 z"
+           id="path7762"
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:url(#linearGradient19121);fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="M -29.645336,58.617611 -40.23683,47.278131 c -0.01069,-0.0115 -0.04435,0.0041 -0.0773,0.035 l -1.497736,1.404798 0.829622,0.892069 1.991607,0.64208 -0.463922,1.000589 3.663605,3.519387 1.277455,-0.21441 -0.255716,1.313054 0.878439,0.944556 1.694669,-0.605735 -0.360019,1.410884 0.813952,0.875218 c 0.0061,0.0065 0.01369,0.01042 0.02228,0.01084 0.0086,4.17e-4 0.01817,-0.0026 0.02509,-0.0091 0,0 1.124579,0.06612 2.049463,0.120267 z"
+           id="path7764"
+           sodipodi:nodetypes="ccccccccccccccscc"
+           inkscape:connector-curvature="0" />
+        <path
+           style="opacity:0.45405405;fill:#73d216;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           d="m -37.804456,43.974752 c -2.446216,-2.266344 -4.273881,-1.79471 -7.392629,-2.505413 l -0.554227,0.519835 c -0.589259,0.552694 -1.493444,0.524272 -2.030303,-0.053 l -0.203857,-0.219199 c -0.335279,-0.360516 -0.389945,-0.831147 -0.281329,-1.283038 -0.763302,-0.385167 -1.381718,-0.832369 -1.971191,-1.308085 -1.31757,2.508353 -1.036612,5.613844 0.923124,7.721088 2.502038,2.690365 6.804061,2.741762 9.603878,0.115683 0.910888,-0.854365 1.543571,-1.890113 1.906534,-2.987873 z"
+           id="path7766"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:#ac8b0b;stroke-width:1.13857627;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m -44.136971,38.153164 0.204392,0.219777 c 0.528984,0.568799 0.48742,1.465133 -0.09319,2.009716 l -1.704844,1.599053 c -0.580613,0.544583 -1.473898,0.52509 -2.00288,-0.04371 l -0.204393,-0.219777 c -0.528984,-0.568799 -0.487419,-1.465133 0.09319,-2.009717 l 1.704843,-1.599052 c 0.580612,-0.544585 1.473896,-0.52509 2.00288,0.04371 z"
+           id="path7768"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path7770"
+           d="m -38.882282,37.092831 c -2.639759,-2.83845 -7.175026,-2.882088 -10.136059,-0.104795 -2.961035,2.777293 -3.227032,7.324265 -0.587274,10.162715 1.980301,2.129354 5.028327,2.687439 7.680143,1.661762 l 0.834359,0.897161 2.260991,0.398932 -0.484113,1.51169 3.181742,2.988125 2.298296,-0.693679 -0.784086,2.321861 0.633496,0.681178 1.951788,-0.866375 -0.370378,1.933823 0.55624,0.598107 c 0.0061,0.0065 0.0069,0.0162 0.01545,0.01661 0.0086,4.18e-4 0.02508,0.0076 0.032,0.0011 0,0 3.133754,0.171346 3.133754,0.171346 0,2e-6 1.268467,-2.434012 1.268467,-2.434012 L -37.703449,44.790264 c 1.143411,-2.565748 0.775216,-5.596308 -1.178833,-7.697433 z m -5.242156,1.05967 0.200864,0.215983 c 0.528984,0.568799 0.479487,1.478864 -0.101125,2.023448 l -1.704481,1.598713 c -0.580613,0.544584 -1.471531,0.516579 -2.000514,-0.05222 l -0.200866,-0.215984 c -0.528983,-0.568798 -0.496036,-1.463343 0.08458,-2.007927 l 1.704479,-1.598712 c 0.580614,-0.544584 1.488082,-0.532101 2.017065,0.0367 z"
+           style="fill:none;stroke:#4e9a06;stroke-width:1.5625;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:nodetypes="csscccccccccccscccccccccccccc"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(0.86602541,0.50000001,-0.50000001,0.86602541,57.792114,-0.77628284)"
+         id="g8562">
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csscccccccccccscccccccccccccc"
+           id="path7742"
+           d="m -10.067686,30.19854 c -2.639759,-2.83845 -7.175026,-2.882088 -10.136059,-0.104795 -2.961035,2.777293 -3.227032,7.324265 -0.587274,10.162715 1.980301,2.129354 5.028327,2.687439 7.680143,1.661762 l 0.834359,0.897161 1.996216,0.647276 -0.466555,0.997519 3.676179,3.519779 1.256755,-0.214473 -0.236983,1.311002 0.880714,0.947004 1.687014,-0.618032 -0.352822,1.419654 0.803458,0.863933 c 0.0061,0.0065 0.0069,0.0162 0.01545,0.01661 0.0086,4.18e-4 0.02508,0.0076 0.032,0.0011 0,0 3.133754,0.171346 3.133754,0.171346 0,2e-6 1.268467,-2.434012 1.268467,-2.434012 L -8.888853,37.895973 c 1.143411,-2.565748 0.775216,-5.596308 -1.178833,-7.697433 z m -5.242156,1.05967 0.200864,0.215983 c 0.528984,0.568799 0.479487,1.478864 -0.101125,2.023448 l -1.704481,1.598713 c -0.580613,0.544584 -1.471531,0.516579 -2.000514,-0.05222 l -0.200866,-0.215984 c -0.528983,-0.568798 -0.496036,-1.463343 0.08458,-2.007927 l 1.704479,-1.598712 c 0.580614,-0.544585 1.488082,-0.532101 2.017065,0.0367 z"
+           style="fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc"
+           id="path7744"
+           d="m -9.480729,38.33088 10.36962,11.484735 c 0.01216,0.01308 0.01308,0.03193 0.0021,0.04227 L 0.366863,50.34949 c -0.01102,0.01034 -0.02969,0.0081 -0.04185,-0.0049 l -10.36966,-11.484784 c -0.01216,-0.01308 -0.01308,-0.03193 -0.0021,-0.04227 l 0.52413,-0.491604 c 0.01102,-0.01034 0.02969,-0.0081 0.04185,0.0049 z"
+           style="fill:url(#linearGradient19123);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccscc"
+           id="path7746"
+           d="M -0.83074,51.72332 -11.422234,40.38384 c -0.01069,-0.0115 -0.04435,0.0041 -0.0773,0.035 l -1.497736,1.404798 0.829622,0.892069 1.991607,0.64208 -0.463922,1.000589 3.663605,3.519387 1.277455,-0.21441 -0.255716,1.313054 0.878439,0.944556 1.694669,-0.605735 -0.360019,1.410884 0.813952,0.875218 c 0.0061,0.0065 0.01369,0.01042 0.02228,0.01084 0.0086,4.17e-4 0.01817,-0.0026 0.02509,-0.0091 0,0 1.124579,0.06612 2.049463,0.120267 z"
+           style="fill:url(#linearGradient19125);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7748"
+           d="m -8.98986,37.080461 c -2.446216,-2.266344 -4.273881,-1.79471 -7.392629,-2.505413 l -0.554227,0.519835 c -0.589259,0.552694 -1.493444,0.524272 -2.030303,-0.053 l -0.203857,-0.219199 c -0.335279,-0.360516 -0.389945,-0.831147 -0.281329,-1.283038 -0.763302,-0.385167 -1.381718,-0.832369 -1.971191,-1.308085 -1.31757,2.508353 -1.036612,5.613844 0.923124,7.721088 2.502038,2.690365 6.804061,2.741762 9.603878,0.115683 0.910888,-0.854365 1.543571,-1.890113 1.906534,-2.987873 z"
+           style="opacity:0.45405405;fill:#3465af;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7750"
+           d="m -15.322375,31.258873 0.204392,0.219777 c 0.528984,0.568799 0.48742,1.465133 -0.09319,2.009716 l -1.704844,1.599053 c -0.580613,0.544583 -1.473898,0.52509 -2.00288,-0.04371 l -0.204393,-0.219777 c -0.528984,-0.568799 -0.487419,-1.465133 0.09319,-2.009717 l 1.704843,-1.599052 c 0.580612,-0.544585 1.473896,-0.52509 2.00288,0.04371 z"
+           style="fill:none;stroke:#ac8b0b;stroke-width:1.13857627;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csscccccccccccscccccccccccccc"
+           style="fill:none;stroke:#204a87;stroke-width:1.5625;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m -10.067686,30.19854 c -2.639759,-2.83845 -7.175026,-2.882088 -10.136059,-0.104795 -2.961035,2.777293 -3.227032,7.324265 -0.587274,10.162715 1.980301,2.129354 5.028327,2.687439 7.680143,1.661762 l 0.834359,0.897161 2.260991,0.398932 -0.484113,1.51169 3.181742,2.988125 2.298296,-0.693679 -0.784086,2.321861 0.633496,0.681178 1.951788,-0.866375 -0.370378,1.933823 0.55624,0.598107 c 0.0061,0.0065 0.0069,0.0162 0.01545,0.01661 0.0086,4.18e-4 0.02508,0.0076 0.032,0.0011 0,0 3.133754,0.171346 3.133754,0.171346 0,2e-6 1.268467,-2.434012 1.268467,-2.434012 L -8.888853,37.895973 c 1.143411,-2.565748 0.775216,-5.596308 -1.178833,-7.697433 z m -5.242156,1.05967 0.200864,0.215983 c 0.528984,0.568799 0.479487,1.478864 -0.101125,2.023448 l -1.704481,1.598713 c -0.580613,0.544584 -1.471531,0.516579 -2.000514,-0.05222 l -0.200866,-0.215984 c -0.528983,-0.568798 -0.496036,-1.463343 0.08458,-2.007927 l 1.704479,-1.598712 c 0.580614,-0.544585 1.488082,-0.532101 2.017065,0.0367 z"
+           id="path7752" />
+      </g>
+      <g
+         clip-path="url(#clipPath16203)"
+         id="g16167"
+         transform="matrix(0.8,0,0,0.8,25.035669,-32.664465)">
+        <path
+           sodipodi:type="arc"
+           style="color:#000000;fill:none;stroke:url(#linearGradient19127);stroke-width:6.27135754;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           id="path16169"
+           sodipodi:cx="17.500893"
+           sodipodi:cy="18.920233"
+           sodipodi:rx="11.048544"
+           sodipodi:ry="11.048544"
+           d="m 28.549437,18.920233 c 0,6.101942 -4.946602,11.048544 -11.048544,11.048544 -6.101943,0 -11.0485443,-4.946602 -11.0485443,-11.048544 0,-6.101943 4.9466013,-11.0485442 11.0485443,-11.0485442 6.101942,0 11.048544,4.9466012 11.048544,11.0485442 z"
+           transform="matrix(1.245743,0,0,1.245743,-33.78694,35.275592)" />
+        <path
+           transform="matrix(1.245743,0,0,1.245743,-33.78694,35.275592)"
+           d="m 28.549437,18.920233 c 0,6.101942 -4.946602,11.048544 -11.048544,11.048544 -6.101943,0 -11.0485443,-4.946602 -11.0485443,-11.048544 0,-6.101943 4.9466013,-11.0485442 11.0485443,-11.0485442 6.101942,0 11.048544,4.9466012 11.048544,11.0485442 z"
+           sodipodi:ry="11.048544"
+           sodipodi:rx="11.048544"
+           sodipodi:cy="18.920233"
+           sodipodi:cx="17.500893"
+           id="path16171"
+           style="color:#000000;fill:none;stroke:#dcdcdc;stroke-width:3.76281476;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:type="arc"
+           style="color:#000000;fill:none;stroke:url(#linearGradient19129);stroke-width:1.25427127;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+           id="path16173"
+           sodipodi:cx="17.500893"
+           sodipodi:cy="18.920233"
+           sodipodi:rx="11.048544"
+           sodipodi:ry="11.048544"
+           d="m 28.549437,18.920233 c 0,6.101942 -4.946602,11.048544 -11.048544,11.048544 -6.101943,0 -11.0485443,-4.946602 -11.0485443,-11.048544 0,-6.101943 4.9466013,-11.0485442 11.0485443,-11.0485442 6.101942,0 11.048544,4.9466012 11.048544,11.0485442 z"
+           transform="matrix(1.245743,0,0,1.245743,-33.78694,35.275592)" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
See [JENKINS-68674](https://issues.jenkins-ci.org/browse/JENKINS-68674).

Before this PR, the icon for the folder credentials in the crumb bar was missing. Now with the change, the icon is back:
<img width="653" alt="folder-icon" src="https://user-images.githubusercontent.com/2143048/171861815-1cb6bd62-b3b9-4670-9a6d-2c5e6eefb1d2.png">

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Icon for folder credentials store has been updated to match credentials plugin change

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
