### PR TITLE
Remove the hierarchal sidebar link

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/tasks-top.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/tasks-top.jelly
@@ -25,7 +25,6 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:this="this">
   <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
-  <l:task icon="icon-up icon-md" href="${url}/../../" title="${%Up}" contextMenu="false"/>
   <l:task icon="icon-search icon-md"  href="${url}/" title="${%Status}" contextMenu="false" />
   <j:choose>
     <j:when test="${h.hasPermission(it,it.CONFIGURE)}">


### PR DESCRIPTION
Tiny PR to remove the hierarchal sidebar link (Up), following the changes in https://github.com/jenkinsci/jenkins/pull/6907 which does the same for the freestyle project type.

---

### Proposed changelog entries

* The hierarchal sidebar link has been removed

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
