### PR TITLE
Restore broken folder credentials icon

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
@@ -249,7 +249,7 @@ public class FolderCredentialsProvider extends CredentialsProvider {
      */
     @Override
     public String getIconClassName() {
-        return "icon-credentials-folder-store";
+        return "icon-folder-store";
     }
 
     /**


### PR DESCRIPTION
`folder-store.svg` was moved from the credentials plugin to the folder plugin, the old reference displays a broken image:
![Screenshot 2022-07-25 at 18 07 48](https://user-images.githubusercontent.com/13383509/180825329-160eadd9-fb30-4c26-ad91-4737449e6cef.png)
The change proposed addresses the issue and restores the icon:
![Screenshot 2022-07-25 at 18 09 33](https://user-images.githubusercontent.com/13383509/180825450-85226572-6dee-4dfa-9314-4867c7dd654f.png)