### PR TITLE
[JENKINS-69914] Remove overcomplicated `checkUrl` (CSP compatibility)

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -861,6 +861,10 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         }
     }
 
+    public FormValidation doCheckDisplayName(@QueryParameter String value, @QueryParameter String jobName) {
+        return Jenkins.get().doCheckDisplayName(value, jobName);
+    }
+
 
     /**
      * Get the current health report for a folder.

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -115,7 +115,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
@@ -860,10 +859,6 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         } else {
             return FormValidation.error(Messages.Hudson_ViewAlreadyExists(view));
         }
-    }
-
-    public FormValidation doCheckDisplayName(@QueryParameter String value, @AncestorInPath AbstractFolder folder) {
-        return Jenkins.get().doCheckDisplayName(value, folder.getName());
     }
 
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -115,6 +115,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
@@ -861,8 +862,8 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         }
     }
 
-    public FormValidation doCheckDisplayName(@QueryParameter String value, @QueryParameter String jobName) {
-        return Jenkins.get().doCheckDisplayName(value, jobName);
+    public FormValidation doCheckDisplayName(@QueryParameter String value, @AncestorInPath AbstractFolder folder) {
+        return Jenkins.get().doCheckDisplayName(value, folder.getName());
     }
 
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolderDescriptor.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolderDescriptor.java
@@ -30,6 +30,7 @@ import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Item;
 import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
+import hudson.util.FormValidation;
 import hudson.views.ViewsTabBar;
 import java.io.File;
 import java.util.ArrayList;
@@ -38,6 +39,8 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import jenkins.model.Jenkins;
 import jenkins.model.ProjectNamingStrategy;
 import org.jenkins.ui.icon.IconSpec;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -128,6 +131,11 @@ public abstract class AbstractFolderDescriptor extends TopLevelItemDescriptor im
         }
         return r;
     }
+
+    public FormValidation doCheckDisplayNameOrNull(@AncestorInPath AbstractFolder folder, @QueryParameter String value) {
+        return Jenkins.get().doCheckDisplayName(value, folder.getName());
+    }
+
 
     /**
      * Needed if it wants Folder are categorized in Jenkins 2.x.

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolderDescriptor.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolderDescriptor.java
@@ -39,6 +39,8 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import jenkins.model.Jenkins;
 import jenkins.model.ProjectNamingStrategy;
 import org.jenkins.ui.icon.IconSpec;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
@@ -132,6 +134,7 @@ public abstract class AbstractFolderDescriptor extends TopLevelItemDescriptor im
         return r;
     }
 
+    @Restricted(NoExternalUse.class)
     public FormValidation doCheckDisplayNameOrNull(@AncestorInPath AbstractFolder folder, @QueryParameter String value) {
         return Jenkins.get().doCheckDisplayName(value, folder.getName());
     }

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -66,7 +66,7 @@ THE SOFTWARE.
 
         <div class="jenkins-!-margin-top-6">
           <f:entry title="${%Display Name}" field="displayNameOrNull">
-            <f:textbox />
+            <f:textbox/>
           </f:entry>
         </div>
 

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -66,7 +66,7 @@ THE SOFTWARE.
 
         <div class="jenkins-!-margin-top-6">
           <f:entry title="${%Display Name}" field="displayNameOrNull">
-            <f:textbox checkUrl="checkDisplayName" checkDependsOn=""/>
+            <f:textbox />
           </f:entry>
         </div>
 

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -66,9 +66,6 @@ THE SOFTWARE.
 
         <div class="jenkins-!-margin-top-6">
           <f:entry title="${%Display Name}" field="displayNameOrNull">
-            <f:invisibleEntry>
-              <f:textbox name="jobName" value="${it.name}"/>
-            </f:invisibleEntry>
             <!--
             TODO Remove block-control class
 
@@ -78,7 +75,7 @@ THE SOFTWARE.
             The save/apply buttons are out of place until the DOM is modified by expanding config elements or by
             resizing the browser window.
             -->
-            <f:textbox clazz="block-control" checkUrl="checkDisplayName" checkDependsOn="jobName"/>
+            <f:textbox clazz="block-control" checkUrl="checkDisplayName" checkDependsOn=""/>
           </f:entry>
         </div>
 

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -66,16 +66,7 @@ THE SOFTWARE.
 
         <div class="jenkins-!-margin-top-6">
           <f:entry title="${%Display Name}" field="displayNameOrNull">
-            <!--
-            TODO Remove block-control class
-
-            Having this forces application of the 2.x UI but it is glitchy if no f:optionalBlock or f:radioBlock
-            elements are in the form (such is the case for the standard Folder implementation).
-
-            The save/apply buttons are out of place until the DOM is modified by expanding config elements or by
-            resizing the browser window.
-            -->
-            <f:textbox clazz="block-control" checkUrl="checkDisplayName" checkDependsOn=""/>
+            <f:textbox checkUrl="checkDisplayName" checkDependsOn=""/>
           </f:entry>
         </div>
 

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -66,6 +66,9 @@ THE SOFTWARE.
 
         <div class="jenkins-!-margin-top-6">
           <f:entry title="${%Display Name}" field="displayNameOrNull">
+            <f:invisibleEntry>
+              <f:textbox name="jobName" value="${it.name}"/>
+            </f:invisibleEntry>
             <!--
             TODO Remove block-control class
 
@@ -75,7 +78,7 @@ THE SOFTWARE.
             The save/apply buttons are out of place until the DOM is modified by expanding config elements or by
             resizing the browser window.
             -->
-            <f:textbox clazz="block-control" checkUrl="'${rootURL}/checkDisplayName?displayName='+encodeURIComponent(this.value)+'&amp;jobName='+encodeURIComponent('${h.jsStringEscape(it.name)}')"/>
+            <f:textbox clazz="block-control" checkUrl="checkDisplayName" checkDependsOn="jobName"/>
           </f:entry>
         </div>
 


### PR DESCRIPTION
Hello, HacktoberFest is here ([Content Security Policy: smooth introduction Topic](https://issues.jenkins.io/browse/JENKINS-60865))

See [JENKINS-69914](https://issues.jenkins.io/browse/JENKINS-69914).

[Content-Security-Policy Compatibility documentation](https://www.jenkins.io/doc/developer/security/csp/#legacy-javascript-checkurl-validation)


Manual testing recoding:


https://user-images.githubusercontent.com/47667812/197193449-126ba19b-fd61-4150-884f-b665da66c3e9.mov




### Submitter checklist

- [X] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Tested manually ~~Appropriate autotests or explanation to why this change has no tests~~
