### PR TITLE
Realign sidepanel with mainpanel through app bars

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -33,13 +33,8 @@ THE SOFTWARE.
     </l:header>
 
     <l:side-panel>
-      <div id="tasks">
-        <div class="jenkins-app-bar">
-          <div class="jenkins-app-bar__content">
-            <h1>${%Configuration}</h1>
-          </div>
-        </div>
-      </div>
+      <l:app-bar title="${%Configuration}"/>
+      <div id="tasks" />
     </l:side-panel>
 
     <l:main-panel>


### PR DESCRIPTION
This PR aligns the sidepanel with the mainpanel, according to recent job configuration view changes and the overall layout known from other job types, e.g., pipelines.

**Before**:
![Screenshot 2022-11-23 at 13 33 06](https://user-images.githubusercontent.com/13383509/203547932-5c8db8d8-ceb9-496e-8fa8-a57e60a4fb64.png)

**After**:
![Screenshot 2022-11-23 at 17 31 41](https://user-images.githubusercontent.com/13383509/203599190-aa619015-fdba-43b3-b76a-3ca70882a917.png)