### PR TITLE
Add missing breadcrumbs to job configuration

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
          xmlns:fo="/lib/folder" xmlns:p="/lib/hudson/project">
   <l:layout title="${it.displayName} Config" permission="${it.EXTENDED_READ}">
     <j:set var="readOnlyMode" value="${!it.hasPermission(it.CONFIGURE)}" />
+    <l:breadcrumb title="${%Configuration}" />
 
     <l:header>
       <script src="${resURL}/jsbundles/section-to-sidebar-items.js" type="text/javascript" defer="true" />


### PR DESCRIPTION
This PR adds missing breadcrumbs to the job configuration page.

**Before**:
![Screenshot 2022-11-23 at 15 39 02](https://user-images.githubusercontent.com/13383509/203574232-5045c9c5-d969-4c34-93a0-235434c43f5e.png)

**After**:
![Screenshot 2022-11-23 at 15 33 43](https://user-images.githubusercontent.com/13383509/203573017-61e8484f-bc11-413b-aafb-9ec60667130c.png)