### PR TITLE
Replaced deprecated CaseInsensitiveComparator with java.lang.String one in tests

### DIFF
--- a/src/test/resources/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolderTest/oldData/jobs/d/config.xml
+++ b/src/test/resources/com/cloudbees/hudson/plugins/folder/views/DefaultFolderViewHolderTest/oldData/jobs/d/config.xml
@@ -19,7 +19,7 @@
         <filterQueue>false</filterQueue>
         <properties class="hudson.model.View$PropertyList"/>
         <jobNames>
-          <comparator class="hudson.util.CaseInsensitiveComparator"/>
+          <comparator class="java.lang.String$CaseInsensitiveComparator"/>
         </jobNames>
         <jobFilters/>
         <columns>


### PR DESCRIPTION
Replaced deprecated CaseInsensitiveComparator with java.lang.String one in tests

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
