### PR TITLE
chore: Parallelize Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,4 +107,17 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>1C</forkCount>
+          <parallel>all</parallel>
+          <useUnlimitedThreads>true</useUnlimitedThreads>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
This will use all available cores to run tests, and parallelize by all - suite/class/method. On machines with multiple cores, this will vastly improve test performance. These times are on my M1 MBP with 10 (8P + 2E) cores. They were reported by maven on running `mvn verify`.

I first ran `mvn verify` and ignored the time.
Then I ran it thrice without this change, and thrice with this change.

All times in seconds.

|        | Run 1 | Run 2 | Run 3 | Average |
| ------ | ----: | ----: | ----: | ------: |
| Before |   183 |   189 |   188 |     187 |
| After  |    85 |    86 |    86 |      86 |
| Savings|       |       |       |     101 |
| %      |       |       |       |      54 |

This only changes the pom. No new tests are added. All existing tests pass.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Parallelize Tests

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
