### PR TITLE
Make `FolderComputation` implement `Loadable`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -29,7 +29,6 @@ import com.thoughtworks.xstream.XStreamException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.ExtensionList;
 import hudson.Util;
-import hudson.XmlFile;
 import hudson.model.Action;
 import hudson.model.BuildableItem;
 import hudson.model.Cause;
@@ -216,13 +215,10 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
             LOGGER.log(Level.WARNING, null, x);
         }
         synchronized (this) {
-            XmlFile file = computation.getDataFile();
-            if (file.exists()) {
-                try {
-                    file.unmarshal(computation);
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Failed to load " + file, e);
-                }
+            try {
+                computation.load();
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to load " + computation, e);
             }
         }
     }


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins/pull/8544, available in our baseline as of https://github.com/jenkinsci/cloudbees-folder-plugin/pull/356. Useful in CloudBees CI, but seems appropriate here anyway so that `getDataFile` is used in a more encapsulated way. (It cannot be `private` since `BranchIndexing` overrides it.)