### PR TITLE
[JENKINS-72611] Forbid updating credentials ID for `IdCredentials`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
@@ -524,7 +524,7 @@ public class FolderCredentialsProvider extends CredentialsProvider {
             checkPermission(CredentialsProvider.UPDATE);
             Map<Domain, List<Credentials>> domainCredentialsMap = getDomainCredentialsMap();
             if (domainCredentialsMap.containsKey(domain)) {
-                if (current instanceof IdCredentials && replacement instanceof IdCredentials) {
+                if (current instanceof IdCredentials || replacement instanceof IdCredentials) {
                     if (!current.equals(replacement)) {
                         throw new IllegalArgumentException("Credentials' IDs do not match, will not update.");
                     }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java
@@ -524,6 +524,11 @@ public class FolderCredentialsProvider extends CredentialsProvider {
             checkPermission(CredentialsProvider.UPDATE);
             Map<Domain, List<Credentials>> domainCredentialsMap = getDomainCredentialsMap();
             if (domainCredentialsMap.containsKey(domain)) {
+                if (current instanceof IdCredentials && replacement instanceof IdCredentials) {
+                    if (!current.equals(replacement)) {
+                        throw new IllegalArgumentException("Credentials' IDs do not match, will not update.");
+                    }
+                }
                 List<Credentials> list = domainCredentialsMap.get(domain);
                 int index = list.indexOf(current);
                 if (index == -1) {

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProviderTest.java
@@ -56,6 +56,7 @@ import org.hamcrest.Matchers;
 import org.hamcrest.StringDescription;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockQueueItemAuthenticator;
@@ -65,6 +66,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThrows;
 
 public class FolderCredentialsProviderTest {
 
@@ -276,6 +278,18 @@ public class FolderCredentialsProviderTest {
             }
             throw e;
         }
+    }
+
+    @Test
+    @Issue("SECURITY-3252")
+    public void cannotUpdateCredentialsId() throws Exception {
+        UsernamePasswordCredentialsImpl cred1 = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "cred1", "Cred 1", "foo", "bar");
+        UsernamePasswordCredentialsImpl cred2 = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "cred2", "Cred 2", "fee", "baz");
+        Folder f = createFolder();
+        CredentialsStore folderStore = getFolderStore(f);
+        folderStore.addCredentials(Domain.global(), cred1);
+
+        assertThrows(IllegalArgumentException.class, () -> folderStore.updateCredentials(Domain.global(), cred1, cred2));
     }
 
     private static class HasCredentialBuilder extends TestBuilder {


### PR DESCRIPTION
See [JENKINS-72611](https://issues.jenkins.io/browse/JENKINS-72611).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->
https://github.com/jenkinsci/cloudbees-folder-plugin/pull/366 caused regressions, so this is another take.

### Proposed changelog entries

* Forbid updating credentials ID for `IdCredentials`

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
