### PR TITLE
[JENKINS-72613] ItemGroup.getItemName override & refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.443-rc34587.821dd1a_8eed9</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/8902 -->
+    <jenkins.version>2.444</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.440</jenkins.version>
+    <jenkins.version>2.443-SNAPSHOT</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/8902 -->
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.443-SNAPSHOT</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/8902 -->
+    <jenkins.version>2.443-rc34587.821dd1a_8eed9</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/8902 -->
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
   </properties>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -497,6 +497,33 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         return configurations;
     }
 
+    @Override
+    public String getItemName(File dir, I item) {
+        ChildNameGenerator<AbstractFolder<I>, I> childNameGenerator = childNameGenerator();
+        String itemName;
+        if (childNameGenerator == null) {
+            itemName = dir.getName();
+        } else {
+            File nameFile = new File(dir, ChildNameGenerator.CHILD_NAME_FILE);
+            if (nameFile.isFile()) {
+                try {
+                    itemName = StringUtils.trimToNull(Files.readString(nameFile.toPath(), StandardCharsets.UTF_8));
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, e, () ->"Caught an IOException while trying to read " + nameFile + ", assuming child name is " + dir.getName());
+                    itemName = null;
+                }
+                if (itemName == null) {
+                    LOGGER.log(Level.WARNING, "{0} was empty, assuming child name is {1}", new Object[]{nameFile, dir.getName()});
+                    itemName = dir.getName();
+                }
+            } else {
+                itemName = dir.getName();
+            }
+        }
+        String finalItemName = itemName;
+        LOGGER.log(Level.FINE, () -> "itemName = " + finalItemName);
+        return itemName;
+    }
 
     protected final I itemsPut(String name, I item) {
         ChildNameGenerator<AbstractFolder<I>, I> childNameGenerator = childNameGenerator();

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -47,7 +47,6 @@ import hudson.model.Failure;
 import hudson.model.HealthReport;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
-import hudson.model.ItemGroupMixIn;
 import hudson.model.Items;
 import hudson.model.Job;
 import hudson.model.ModifiableViewGroup;
@@ -71,9 +70,8 @@ import hudson.util.HttpResponses;
 import hudson.views.DefaultViewsTabBar;
 import hudson.views.ViewsTabBar;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -102,7 +100,6 @@ import jenkins.model.ProjectNamingStrategy;
 import jenkins.model.TransientActionFactory;
 import net.sf.json.JSONObject;
 import org.acegisecurity.AccessDeniedException;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpRedirect;
@@ -337,216 +334,73 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         final ChildNameGenerator<AbstractFolder<V>,V> childNameGenerator = parent.childNameGenerator();
         Map<String,V> byDirName = new HashMap<>();
         if (parent.items != null) {
-            if (childNameGenerator == null) {
-                for (V item : parent.items.values()) {
-                    byDirName.put(item.getName(), item);
-                }
-            } else {
-                for (V item : parent.items.values()) {
-                    String itemName = childNameGenerator.dirNameFromItem(parent, item);
-                    if (itemName == null) {
-                        itemName = childNameGenerator.dirNameFromLegacy(parent, item.getName());
-                    }
-                    byDirName.put(itemName, item);
-                }
+            for (V item : parent.items.values()) {
+                byDirName.put(childNameGenerator.dirNameFromItem(parent, item), item);
             }
         }
         for (File subdir : subdirs) {
+            File effectiveSubdir = subdir;
+            String childName = childNameGenerator.readItemName(subdir);
+            // Try to retain the identity of an existing child object if we can.
+            V itemFromDir;
+            V item;
+            boolean itemNeedsSave = false;
+            String name;
+            item = itemFromDir = byDirName.get(childName);
+            var legacyName = subdir.getName();
             try {
-                boolean legacy;
-                String childName;
-                if (childNameGenerator == null) {
-                    // the directory name is the item name
-                    childName = subdir.getName();
-                    legacy = false;
-                } else {
-                    File nameFile = new File(subdir, ChildNameGenerator.CHILD_NAME_FILE);
-                    if (nameFile.isFile()) {
-                        childName = StringUtils.trimToNull(Files.readString(nameFile.toPath(), StandardCharsets.UTF_8));
-                        if (childName == null) {
-                            LOGGER.log(Level.WARNING, "{0} was empty, assuming child name is {1}",
-                                            new Object[]{nameFile, subdir.getName()});
-                            legacy = true;
-                            childName = subdir.getName();
-                        } else {
-                            legacy = false;
-                        }
-                    } else {
-                        // this is a legacy name
-                        legacy = true;
-                        childName = subdir.getName();
-                    }
-                }
-                // Try to retain the identity of an existing child object if we can.
-                V item = byDirName.get(childName);
-                boolean itemNeedsSave = false;
                 if (item == null) {
                     XmlFile xmlFile = Items.getConfigFile(subdir);
                     if (xmlFile.exists()) {
                         item = (V) xmlFile.read();
-                        String name;
-                        if (childNameGenerator == null) {
-                            name = subdir.getName();
-                        } else {
-                            String dirName = childNameGenerator.dirNameFromItem(parent, item);
-                            if (dirName == null) {
-                                dirName = childNameGenerator.dirNameFromLegacy(parent, childName);
-                                BulkChange bc = new BulkChange(item); // suppress any attempt to save as parent not set
-                                try {
-                                    childNameGenerator.recordLegacyName(parent, item, childName);
-                                    itemNeedsSave = true;
-                                } catch (IOException e) {
-                                    LOGGER.log(Level.WARNING, "Ignoring {0} as could not record legacy name",
-                                            subdir);
-                                    continue;
-                                } finally {
-                                    bc.abort();
-                                }
-                            }
-                            if (!subdir.getName().equals(dirName)) {
-                                File newSubdir = parent.getRootDirFor(dirName);
-                                if (newSubdir.exists()) {
-                                    LOGGER.log(Level.WARNING, "Ignoring {0} as folder naming rules collide with {1}",
-                                                    new Object[]{subdir, newSubdir});
-                                    continue;
-
-                                }
-                                LOGGER.log(Level.INFO, "Moving {0} to {1} in accordance with folder naming rules",
-                                        new Object[]{subdir, newSubdir});
-                                if (!subdir.renameTo(newSubdir)) {
-                                    LOGGER.log(Level.WARNING, "Failed to move {0} to {1}. Ignoring this item",
-                                            new Object[]{subdir, newSubdir});
-                                    continue;
-                                }
-                            }
-                            File nameFile = new File(parent.getRootDirFor(dirName), ChildNameGenerator.CHILD_NAME_FILE);
-                            name = childNameGenerator.itemNameFromItem(parent, item);
-                            if (name == null) {
-                                name = childNameGenerator.itemNameFromLegacy(parent, childName);
-                                Files.writeString(nameFile.toPath(), name, StandardCharsets.UTF_8);
-                                BulkChange bc = new BulkChange(item); // suppress any attempt to save as parent not set
-                                try {
-                                    childNameGenerator.recordLegacyName(parent, item, childName);
-                                    itemNeedsSave = true;
-                                } catch (IOException e) {
-                                    LOGGER.log(Level.WARNING, "Ignoring {0} as could not record legacy name",
-                                            subdir);
-                                    continue;
-                                } finally {
-                                    bc.abort();
-                                }
-                            } else if (!childName.equals(name) || legacy) {
-                                Files.writeString(nameFile.toPath(), name, StandardCharsets.UTF_8);
-                            }
-                        }
-                        item.onLoad(parent, name);
+                        var dirNameResult = childNameGenerator.ensureItemDirectory(parent, item, subdir);
+                        itemNeedsSave |= dirNameResult.isItemNeedsSave();
+                        effectiveSubdir = dirNameResult.getWrapped();
                     } else {
-                        LOGGER.log(Level.WARNING, "could not find file " + xmlFile.getFile());
-                        continue;
-                    }
-                } else {
-                    String name;
-                    if (childNameGenerator == null) {
-                        name = subdir.getName();
-                    } else {
-                        File nameFile = new File(subdir, ChildNameGenerator.CHILD_NAME_FILE);
-                        name = childNameGenerator.itemNameFromItem(parent, item);
-                        if (name == null) {
-                            name = childNameGenerator.itemNameFromLegacy(parent, childName);
-                            Files.writeString(nameFile.toPath(), name, StandardCharsets.UTF_8);
-                            BulkChange bc = new BulkChange(item); // suppress any attempt to save as parent not set
-                            try {
-                                childNameGenerator.recordLegacyName(parent, item, childName);
-                                itemNeedsSave = true;
-                            } catch (IOException e) {
-                                LOGGER.log(Level.WARNING, "Ignoring {0} as could not record legacy name",
-                                        subdir);
-                                continue;
-                            } finally {
-                                bc.abort();
-                            }
-                        } else if (!childName.equals(name) || legacy) {
-                            Files.writeString(nameFile.toPath(), name, StandardCharsets.UTF_8);
-                        }
-                        if (!subdir.getName().equals(name) && item instanceof AbstractItem
-                                && ((AbstractItem) item).getDisplayNameOrNull() == null) {
-                            BulkChange bc = new BulkChange(item);
-                            try {
-                                ((AbstractItem) item).setDisplayName(childName);
-                            } finally {
-                                bc.abort();
-                            }
-                        }
-                    }
-                    item.onLoad(parent, name);
-                }
-                if (itemNeedsSave) {
-                    try {
-                        item.save();
-                    } catch (IOException e) {
-                        LOGGER.log(Level.WARNING, "Could not update {0} after applying folder naming rules",
-                                item.getFullName());
+                        throw new FileNotFoundException("Could not find configuration file " + xmlFile.getFile());
                     }
                 }
+                var writeResult = childNameGenerator.writeItemName(parent, item, effectiveSubdir, childName);
+                name = writeResult.getWrapped();
+                itemNeedsSave |= writeResult.isItemNeedsSave();
+                if (item instanceof AbstractItem) {
+                    var abstractItem = (AbstractItem) item;
+                    if (itemFromDir != null && !legacyName.equals(name) && abstractItem.getDisplayNameOrNull() == null) {
+                        try (BulkChange ignored = new BulkChange(item)) {
+                            abstractItem.setDisplayName(childName);
+                        }
+                    }
+                }
+                item.onLoad(parent, name);
+                saveIfNeeded(item, itemNeedsSave);
                 configurations.put(key.apply(item), item);
             } catch (Exception e) {
-                Logger.getLogger(ItemGroupMixIn.class.getName()).log(Level.WARNING, "could not load " + subdir, e);
+                File finalEffectiveSubdir = effectiveSubdir;
+                LOGGER.log(Level.WARNING, e, () -> "could not load " + finalEffectiveSubdir);
             }
         }
 
         return configurations;
     }
 
-    @Override
-    public String getItemName(File dir, I item) {
-        ChildNameGenerator<AbstractFolder<I>, I> childNameGenerator = childNameGenerator();
-        String itemName;
-        if (childNameGenerator == null) {
-            itemName = dir.getName();
-        } else {
-            File nameFile = new File(dir, ChildNameGenerator.CHILD_NAME_FILE);
-            if (nameFile.isFile()) {
-                try {
-                    itemName = StringUtils.trimToNull(Files.readString(nameFile.toPath(), StandardCharsets.UTF_8));
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, e, () ->"Caught an IOException while trying to read " + nameFile + ", assuming child name is " + dir.getName());
-                    itemName = null;
-                }
-                if (itemName == null) {
-                    LOGGER.log(Level.WARNING, "{0} was empty, assuming child name is {1}", new Object[]{nameFile, dir.getName()});
-                    itemName = dir.getName();
-                }
-            } else {
-                itemName = dir.getName();
+    private static <V extends TopLevelItem> void saveIfNeeded(V item, boolean itemNeedsSave) {
+        if (itemNeedsSave) {
+            try {
+                item.save();
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Could not update {0} after applying folder naming rules",
+                        item.getFullName());
             }
         }
-        String finalItemName = itemName;
-        LOGGER.log(Level.FINE, () -> "itemName = " + finalItemName);
-        return itemName;
+    }
+
+    @Override
+    public String getItemName(File dir, I item) {
+        return childNameGenerator().readItemName(dir);
     }
 
     protected final I itemsPut(String name, I item) {
-        ChildNameGenerator<AbstractFolder<I>, I> childNameGenerator = childNameGenerator();
-        if (childNameGenerator != null) {
-            File nameFile = new File(getRootDirFor(item), ChildNameGenerator.CHILD_NAME_FILE);
-            String oldName;
-            if (nameFile.isFile()) {
-                try {
-                    oldName = StringUtils.trimToNull(Files.readString(nameFile.toPath(), StandardCharsets.UTF_8));
-                } catch (IOException e) {
-                    oldName = null;
-                }
-            } else {
-                oldName = null;
-            }
-            if (!name.equals(oldName)) {
-                try {
-                    Files.writeString(nameFile.toPath(), name, StandardCharsets.UTF_8);
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Could not create " + nameFile);
-                }
-            }
-        }
+        childNameGenerator().writeItemName(this, item, getRootDirFor(item), name);
         return items.put(name, item);
     }
 
@@ -582,15 +436,11 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
                         LOGGER.log(Level.INFO, String.format("Loading job %s (%.1f%%)", fullName, percentage));
                         loadingTick = now;
                     }
-                    if (childNameGenerator == null) {
-                        return item.getName();
-                    } else {
-                        String childName = childNameGenerator.itemNameFromItem(AbstractFolder.this, item);
-                        if (childName == null) {
-                            return childNameGenerator.itemNameFromLegacy(AbstractFolder.this, item.getName());
-                        }
-                        return childName;
+                    String childName = childNameGenerator.itemNameFromItem(AbstractFolder.this, item);
+                    if (childName == null) {
+                        return childNameGenerator.itemNameFromLegacy(AbstractFolder.this, item.getName());
                     }
+                    return childName;
             });
         } finally {
             t.setName(n);
@@ -641,11 +491,8 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
 
     @Override
     public File getRootDirFor(I child) {
-        ChildNameGenerator<AbstractFolder<I>,I> childNameGenerator = childNameGenerator();
-        if (childNameGenerator == null) {
-            return getRootDirFor(child.getName());
-        }
-        String name = childNameGenerator.dirNameFromItem(this, child);
+        var childNameGenerator = childNameGenerator();
+        var name = childNameGenerator.dirNameFromItem(this, child);
         if (name == null) {
             name = childNameGenerator.dirNameFromLegacy(this, child.getName());
         }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolderDescriptor.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolderDescriptor.java
@@ -26,6 +26,7 @@ package com.cloudbees.hudson.plugins.folder;
 
 import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
 import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Item;
 import hudson.model.TopLevelItem;
@@ -35,7 +36,6 @@ import hudson.views.ViewsTabBar;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import jenkins.model.Jenkins;
 import jenkins.model.ProjectNamingStrategy;
 import org.jenkins.ui.icon.IconSpec;
@@ -216,9 +216,41 @@ public abstract class AbstractFolderDescriptor extends TopLevelItemDescriptor im
      */
     // TODO figure out how one could un-wind name mangling if one ever wanted to
     // TODO move the name mangling code from branch-api to this plugin so that everyone can use it
-    @CheckForNull
+    @NonNull
     public <I extends TopLevelItem> ChildNameGenerator<AbstractFolder<I>,I> childNameGenerator() {
-        return null;
+        return new LegacyChildNameGenerator<>();
     }
 
+    /**
+     * A {@link ChildNameGenerator} that does not mangle the names of child items.
+     * @param <I>
+     */
+    private static class LegacyChildNameGenerator<I extends TopLevelItem>  extends ChildNameGenerator<AbstractFolder<I>,I> {
+        @Override
+        public String itemNameFromItem(@NonNull AbstractFolder<I> parent, @NonNull I item) {
+            return item.getName();
+        }
+
+        @Override
+        public String dirNameFromItem(@NonNull AbstractFolder<I> parent, @NonNull I item) {
+            return item.getName();
+        }
+
+        @NonNull
+        @Override
+        public String itemNameFromLegacy(@NonNull AbstractFolder<I> parent, @NonNull String legacyDirName) {
+            return legacyDirName;
+        }
+
+        @NonNull
+        @Override
+        public String dirNameFromLegacy(@NonNull AbstractFolder<I> parent, @NonNull String legacyDirName) {
+            return legacyDirName;
+        }
+
+        @Override
+        public void recordLegacyName(AbstractFolder<I> parent, I item, String legacyDirName) {
+            // no-op
+        }
+    }
 }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
@@ -33,6 +33,7 @@ import hudson.Util;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
+import hudson.model.Items;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -271,14 +272,12 @@ public class ChildNameGeneratorAltTest {
         String encodedName = encode(idealName);
         FreeStyleProject item = instance.getItem(encodedName);
         assertThat("We have an item for name " + idealName, item, notNullValue());
+        var itemRootDir = item.getRootDir();
         assertThat("The root directory if the item for name " + idealName + " is mangled",
-                item.getRootDir().getName(), is(mangle(idealName)));
-        File nameFile = new File(item.getRootDir(), ChildNameGenerator.CHILD_NAME_FILE);
-        assertThat("We have the " + ChildNameGenerator.CHILD_NAME_FILE + " for the item for name " + idealName,
-                nameFile.isFile(), is(true));
-        String name = Files.readString(nameFile.toPath(), StandardCharsets.UTF_8);
-        assertThat("The " + ChildNameGenerator.CHILD_NAME_FILE + " for the item for name " + idealName
-                + " contains the encoded name", name, is(encodedName));
+                itemRootDir.getName(), is(mangle(idealName)));
+        var loadedItemFromDisk = (FreeStyleProject) Items.load(instance, itemRootDir);
+        var itemName = instance.getItemName(itemRootDir, loadedItemFromDisk);
+        assertThat("The item name after reading back the item root dir should be encoded", itemName, is(encodedName));
     }
 
     public static String encode(String s) {

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
@@ -33,7 +33,6 @@ import hudson.Util;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
-import hudson.model.Items;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -272,12 +271,14 @@ public class ChildNameGeneratorAltTest {
         String encodedName = encode(idealName);
         FreeStyleProject item = instance.getItem(encodedName);
         assertThat("We have an item for name " + idealName, item, notNullValue());
-        var itemRootDir = item.getRootDir();
         assertThat("The root directory if the item for name " + idealName + " is mangled",
-                itemRootDir.getName(), is(mangle(idealName)));
-        var loadedItemFromDisk = (FreeStyleProject) Items.load(instance, itemRootDir);
-        var itemName = instance.getItemName(itemRootDir, loadedItemFromDisk);
-        assertThat("The item name after reading back the item root dir should be encoded", itemName, is(encodedName));
+                item.getRootDir().getName(), is(mangle(idealName)));
+        File nameFile = new File(item.getRootDir(), ChildNameGenerator.CHILD_NAME_FILE);
+        assertThat("We have the " + ChildNameGenerator.CHILD_NAME_FILE + " for the item for name " + idealName,
+                nameFile.isFile(), is(true));
+        String name = Files.readString(nameFile.toPath(), StandardCharsets.UTF_8);
+        assertThat("The " + ChildNameGenerator.CHILD_NAME_FILE + " for the item for name " + idealName
+                + " contains the encoded name", name, is(encodedName));
     }
 
     public static String encode(String s) {

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -184,6 +184,12 @@ public class FolderTest {
                 .getPage(request).getWebResponse().getStatusCode());
     }
 
+    @Test public void itemName() throws IOException {
+        Folder f = createFolder();
+        var foo = f.createProject(FreeStyleProject.class, "foo");
+        assertEquals("foo", f.getItemName(foo.getRootDir(), foo));
+    }
+
     /**
      * When copying a folder, its contents need to be recursively copied.
      */


### PR DESCRIPTION
A more invasive approach to #367, including refactor of `AbstractFolder` & `ChildNameGenerator` to avoid the copy-pasta lookalike code that was caused by the previous design. 

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
