### PR TITLE
`AbstractFolder.reloadThis` & `.addLoadedChild`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
@@ -347,10 +347,7 @@ public class Folder extends AbstractFolder<TopLevelItem> implements DirectlyModi
         if (!canAdd(item)) {
             throw new IllegalArgumentException();
         }
-        if (items.containsKey(name)) {
-            throw new IllegalArgumentException("already an item '" + name + "'");
-        }
-        itemsPut(item.getName(), item);
+        addLoadedChild(item, name);
         return item;
     }
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -209,6 +209,10 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
     @Override
     public void onLoad(ItemGroup<? extends Item> parent, String name) throws IOException {
         super.onLoad(parent, name);
+        if (reloadingThis.get()) {
+            LOGGER.fine(() -> this + " skipping the rest of onLoad");
+            return;
+        }
         try {
             FileUtils.forceMkdir(getComputationDir());
         } catch (IOException x) {


### PR DESCRIPTION
In CloudBees CI running in high availability mode we need to synchronize various `Item`s from disk. Handling simple items like `Job`s is straightforward enough: when `config.xml` changes on disk, reload it. (https://github.com/jenkinsci/jenkins/pull/8544 makes this cleaner and more explicit.) But folders are more complicated:

* If an item inside the folder is updated, fine—just reload it. (Same as an item at top level.)
* If an item inside the folder is removed, just delete it.
* If an item inside a _plain_ `Folder` is created, there is an existing method to add it in memory.
* If an item inside a `ComputedFolder` is created, there was no way to insert it into the child list in memory.
* If the folder itself is modified, it was possible to reload the folder _but_ this would also reload all the children, which was very wasteful.

Both new methods are exercised by functional tests in CloudBees CI. I am not sure if some OSS tools would find these useful. JCasC does not cover `Item`s. `job-dsl` does, but does not deal with configuration on disk. The relevant scenario is that a tool creates, modifies, and deletes `$JENKINS_HOME/jobs/**/config.xml` and then tries to reflect those changes in a running controller process with minimal disruption and overhead.
