### PR TITLE
Use symbol for folder icon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.444</jenkins.version>
+    <jenkins.version>2.454</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
   </properties>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolderDescriptor.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolderDescriptor.java
@@ -155,7 +155,7 @@ public abstract class AbstractFolderDescriptor extends TopLevelItemDescriptor im
      */
     @Override
     public String getIconClassName() {
-        return "icon-folder";
+        return "symbol-folder-outline plugin-ionicons-api";
     }
 
     public boolean isIconConfigurable() {


### PR DESCRIPTION
Follow up to @mawinter69 changes in core (https://github.com/jenkinsci/jenkins/pull/9127). This PR uses the folder symbol now that the 'New item' page supports displaying them.

**Before**
<img width="844" alt="image" src="https://github.com/jenkinsci/cloudbees-folder-plugin/assets/43062514/a431ab05-e5dc-42c3-9cae-fd6d3a44715f">

**After**
<img width="884" alt="image" src="https://github.com/jenkinsci/cloudbees-folder-plugin/assets/43062514/a6e3dc20-08d0-4cfc-a29d-3451a73c5d56">

### Proposed changelog entries

* Use symbol for folder icon

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
