### PR TITLE
[JENKINS-73086] Allow users with Overall/Manage permission to configure global default folder settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,9 @@
     <jenkins.version>2.454</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
+    <useBeta>true</useBeta> <!-- needed for Jenkins.MANAGE support -->
   </properties>
+
   <licenses>
     <license>
       <name>MIT</name>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/config/AbstractFolderConfiguration.java
@@ -5,8 +5,10 @@ import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import hudson.security.Permission;
 import hudson.util.DescribableList;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -22,6 +24,13 @@ import java.util.List;
 public class AbstractFolderConfiguration extends GlobalConfiguration {
 
     private List<FolderHealthMetric> healthMetrics;
+
+
+    @NonNull
+    @Override
+    public Permission getRequiredGlobalConfigPagePermission() {
+        return Jenkins.MANAGE;
+    }
 
     @NonNull
     public static AbstractFolderConfiguration get() {


### PR DESCRIPTION
See [JENKINS-73086](https://issues.jenkins-ci.org/browse/JENKINS-73086).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
