### PR TITLE
Remove disable button to match other job type since 2.460

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,9 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.454</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.462</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
     <useBeta>true</useBeta> <!-- needed for Jenkins.MANAGE support -->
@@ -58,8 +60,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.440.x</artifactId>
-        <version>2982.vdce2153031a_0</version>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3276.vcd71db_867fb_2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
@@ -53,25 +53,6 @@ THE SOFTWARE.
     <j:when test="${!it.supportsMakeDisabled()}">
       <!-- for now, quietly omit the option -->
     </j:when>
-    <j:when test="${it.disabled}">
-      <div class="warning">
-        <form method="post" id='enable-project' action="${rootURL}/${it.url}enable">
-          ${%disabled(it.pronoun)}<st:nbsp/>
-          <l:hasPermission permission="${it.CONFIGURE}">
-            <f:submit value="${%Enable}"/>
-          </l:hasPermission>
-        </form>
-      </div>
-    </j:when>
-    <j:otherwise>
-      <div align="right">
-        <form method="post" id="disable-project" action="${rootURL}/${it.url}disable">
-          <l:hasPermission permission="${it.CONFIGURE}">
-            <f:submit value="${%disable(it.pronoun)}"/>
-          </l:hasPermission>
-        </form>
-      </div>
-    </j:otherwise>
   </j:choose>
   <!-- give actions a chance to contribute summary item -->
   <j:forEach var="a" items="${it.allActions}">

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -609,45 +609,6 @@ public class ComputedFolderTest {
         waitUntilNoActivityIgnoringThreadDeathUpTo(10000);
         d.checkRename("d2");
     }
-    
-    @Issue("JENKINS-60900")
-    @Test
-    public void enabledAndDisableFromUi() throws Exception {
-        SampleComputedFolder folder = r.jenkins.createProject(SampleComputedFolder.class, "d");
-        assertFalse("by default, a folder is disabled", folder.isDisabled());
-        HtmlForm cfg = (HtmlForm)r.createWebClient().getPage(folder).getElementById("disable-project");
-        assertNotNull(cfg);
-        // Disable the folder
-        r.submit(cfg);
-        assertTrue(folder.isDisabled());
-        cfg = (HtmlForm)r.createWebClient().getPage(folder).getElementById("enable-project");
-        assertNotNull(cfg);
-        // Re enable the folder
-        r.submit(cfg);
-        assertFalse(folder.isDisabled());
-    }
-
-    @Issue("JENKINS-66168")
-    @Test
-    public void enabledAndDisableFromUiViews() throws Exception {
-        LockedDownSampleComputedFolder folder = r.jenkins.createProject(LockedDownSampleComputedFolder.class, "d");
-        assertFalse("by default, a folder is disabled", folder.isDisabled());
-        folder.getViews().forEach(view -> {
-            try {
-                String viewUrl =view.getViewUrl();
-                HtmlForm cfg = (HtmlForm) r.createWebClient().goTo(viewUrl).getElementById("disable-project");
-                assertNotNull(cfg);
-                r.submit(cfg);
-                assertTrue("Can disable from view " + view.getViewName(), folder.isDisabled());
-                cfg = (HtmlForm) r.createWebClient().goTo(viewUrl).getElementById("enable-project");
-                assertNotNull(cfg);
-                r.submit(cfg);
-                assertFalse("Can enable from view " + view.getViewName(), folder.isDisabled());
-            } catch (Exception e) {
-                Assert.fail();
-            }
-        });
-    }
 
     @Test
     public void failAllDeletedOnes() throws Exception {


### PR DESCRIPTION
Remove disable button to match other job type since 2.460

I can open an Jira ticket if needed

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Remove disable button to match other job type since 2.460

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
