### PR TITLE
Gratuitous `save` from `AbstractFolder.onDeleted/onRenamed`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -963,7 +963,6 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         for (View v : folderViews.getViews()) {
             v.onJobRenamed(item, oldName, newName);
         }
-        save();
     }
 
     /**
@@ -978,7 +977,6 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         for (View v : folderViews.getViews()) {
             v.onJobRenamed(item, item.getName(), null);
         }
-        save();
     }
 
     /**


### PR DESCRIPTION
While testing some scenarios involving job deletion in CloudBees CI, we found some anomalous events caused by a save event on `config.xml` of the parent folder. This makes no apparent sense, because the folder is not being modified.