### PR TITLE
[JENKINS-73930] Put back the disabled warning

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
@@ -53,6 +53,9 @@ THE SOFTWARE.
     <j:when test="${!it.supportsMakeDisabled()}">
       <!-- for now, quietly omit the option -->
     </j:when>
+    <j:when test="${it.disabled}">
+      <div id="disabled-message" class="warning">${%disabled(it.pronoun)}</div>
+    </j:when>
   </j:choose>
   <!-- give actions a chance to contribute summary item -->
   <j:forEach var="a" items="${it.allActions}">

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -630,22 +630,14 @@ public class ComputedFolderTest {
     public void disabledWarningFromUiViews() throws Exception {
         LockedDownSampleComputedFolder folder = r.jenkins.createProject(LockedDownSampleComputedFolder.class, "d");
         assertFalse("by default, a folder is disabled", folder.isDisabled());
-        folder.getViews().forEach(view -> {
-            try {
-                assertNull(r.createWebClient().goTo(view.getViewUrl()).getElementById("disabled-message"));
-            } catch (Exception e) {
-                Assert.fail();
-            }
-        });
+        for(View view : folder.getViews()){
+            assertNull(r.createWebClient().goTo(view.getViewUrl()).getElementById("disabled-message"));
+        }
         folder.setDisabled(true);
         folder.save();
-        folder.getViews().forEach(view -> {
-            try {
-                assertNotNull(r.createWebClient().goTo(view.getViewUrl()).getElementById("disabled-message"));
-            } catch (Exception e) {
-                Assert.fail();
-            }
-        });
+        for(View view : folder.getViews()){
+            assertNotNull(r.createWebClient().goTo(view.getViewUrl()).getElementById("disabled-message"));
+        }
     }
 
     /**

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -40,7 +41,6 @@ import com.cloudbees.hudson.plugins.folder.AbstractFolderDescriptor;
 import com.cloudbees.hudson.plugins.folder.Folder;
 import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
 import org.htmlunit.html.DomElement;
-import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -623,6 +623,29 @@ public class ComputedFolderTest {
 
         // But B has been deleted
         d.assertItemNames(2, "A");
+    }
+
+    @Issue("JENKINS-73930")
+    @Test
+    public void disabledWarningFromUiViews() throws Exception {
+        LockedDownSampleComputedFolder folder = r.jenkins.createProject(LockedDownSampleComputedFolder.class, "d");
+        assertFalse("by default, a folder is disabled", folder.isDisabled());
+        folder.getViews().forEach(view -> {
+            try {
+                assertNull(r.createWebClient().goTo(view.getViewUrl()).getElementById("disabled-message"));
+            } catch (Exception e) {
+                Assert.fail();
+            }
+        });
+        folder.setDisabled(true);
+        folder.save();
+        folder.getViews().forEach(view -> {
+            try {
+                assertNotNull(r.createWebClient().goTo(view.getViewUrl()).getElementById("disabled-message"));
+            } catch (Exception e) {
+                Assert.fail();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-73930](https://issues.jenkins.io/browse/JENKINS-73930). Amend 

The button was removed from https://github.com/jenkinsci/cloudbees-folder-plugin/pull/419. But along with the warning. It is not obvious anymore when a folder is disabled.

Before:

![before](https://github.com/user-attachments/assets/d412c7e2-6adb-45e6-8570-fa2ebeb88c98)


After:

![after](https://github.com/user-attachments/assets/b60a96b7-a497-4e42-97d1-19373b9d01fa)


### Proposed changelog entries

* Re-instaore the Disabled warning when a Folder is disabled

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
