### PR TITLE
Fix primaryView & viewsTabBar missing when views are empty

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -302,7 +302,11 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Failed to set up the initial view", e);
         }
-        return new DefaultFolderViewHolder(views, null, newDefaultViewsTabBar());
+        if (primaryView != null) {
+            primaryView = AllView.migrateLegacyPrimaryAllViewLocalizedName(views, primaryView);
+        }
+        return new DefaultFolderViewHolder(views, primaryView, viewsTabBar == null ? newDefaultViewsTabBar()
+                : viewsTabBar);
     }
 
     protected FolderIcon newDefaultFolderIcon() {


### PR DESCRIPTION
Fix primaryView & viewsTabBar missing when views are empty

When you create a folder job through XML API such as jenkins-job-builder, you will follow the following steps to create jobs. 
1. Create folders.
2. Create jobs
3. Create views. 

When creating the folder job, the views are still empty, and the values ​​of primaryView and viewsTabBar will be lost.

### Proposed changelog entries

* Entry 1: Fix primaryView & viewsTabBar missing when views are empty
* ...

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
