### PR TITLE
[JENKINS-72958] expose buildable property to API

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder.java
@@ -84,6 +84,7 @@ import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
@@ -528,6 +529,7 @@ public abstract class ComputedFolder<I extends TopLevelItem> extends AbstractFol
      *
      * @return {@code true} if this folder can currently be recomputed.
      */
+    @Exported
     public boolean isBuildable() {
         if (isDisabled()) {
             return false;


### PR DESCRIPTION
https://github.com/jenkinsci/branch-api-plugin/pull/468 but on the base class that defines `isBuildable`

See [JENKINS-73425](https://issues.jenkins.io/browse/JENKINS-73425).

Obsoletes https://github.com/jenkinsci/branch-api-plugin/pull/468 (untested)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Expose `buildable` for ComputedFolders to the REST API

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
