### PR TITLE
Defend against null `AbstractFolder.primaryView`

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/sidepanel.jelly
@@ -23,8 +23,11 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-    <j:if test="${view == null}"> <!-- true when rendering from ModelObjectWithContextMenu.ContextMenu.from -->
-        <j:set var="view" value="${it.primaryView}"/>
+    <j:set var="primaryView" value="${it.primaryView}"/>
+    <j:if test="${primaryView != null}">
+        <j:if test="${view == null}"> <!-- true when rendering from ModelObjectWithContextMenu.ContextMenu.from -->
+            <j:set var="view" value="${primaryView}"/>
+        </j:if>
+        <st:include it="${primaryView}" page="sidepanel.jelly"/>
     </j:if>
-    <st:include it="${it.primaryView}" page="sidepanel.jelly"/>
 </j:jelly>


### PR DESCRIPTION
Not observed as such, but seems possible from code inspection. See https://github.com/jenkinsci/jenkins/pull/10023.