### PR TITLE
Define `FolderComputation.fullName` for use from `OldDataMonitor`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
@@ -72,6 +72,7 @@ import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.diagnosis.OldDataMonitor;
 import javax.servlet.ServletException;
 import net.jcip.annotations.GuardedBy;
 import java.nio.charset.StandardCharsets;
@@ -291,6 +292,14 @@ public class FolderComputation<I extends TopLevelItem> extends Actionable implem
     @Override
     public String getDisplayName() {
         return AlternativeUiTextProvider.get(DISPLAY_NAME, this, Messages.FolderComputation_DisplayName());
+    }
+
+    /**
+     * May be used by {@link OldDataMonitor} in its {@code manage} view.
+     * @return {@link ComputedFolder#getFullName}
+     */
+    public String getFullName() {
+        return folder.getFullName();
     }
 
     /**


### PR DESCRIPTION
I noticed `OldDataMonitor` showing _Scan Repository_ under **Name** for a `BranchIndexing`, which was not very helpful; I had to use the script console to find the exact `indexing.xml` affected. https://github.com/jenkinsci/jenkins/blob/810c4b41613aafe0e0ac491b8e6013d92ed1ea26/core/src/main/resources/hudson/diagnosis/OldDataMonitor/manage.jelly#L51 is the logic here (called reflectively, alas, which is why this does not `@Override` anything).

Tested interactively as part of a bug fix in CloudBees CI.