### PR TITLE
[JENKINS-74990] Prevent stack overflow / Revert 'Add icons for search'

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -101,7 +101,6 @@ import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ProjectNamingStrategy;
 import jenkins.model.TransientActionFactory;
 import net.sf.json.JSONObject;
-import org.jenkins.ui.icon.IconSpec;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -135,7 +134,7 @@ import org.springframework.security.access.AccessDeniedException;
  */
 @SuppressWarnings({"unchecked", "rawtypes"}) // mistakes in various places
 @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE") // https://github.com/spotbugs/spotbugs/issues/1539
-public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractItem implements TopLevelItem, ItemGroup<I>, ModifiableViewGroup, StaplerFallback, ModelObjectWithChildren, StaplerOverridable, IconSpec {
+public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractItem implements TopLevelItem, ItemGroup<I>, ModifiableViewGroup, StaplerFallback, ModelObjectWithChildren, StaplerOverridable {
 
     /**
      * Our logger.
@@ -304,11 +303,6 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
             LOGGER.log(Level.WARNING, "Failed to set up the initial view", e);
         }
         return new DefaultFolderViewHolder(views, null, newDefaultViewsTabBar());
-    }
-
-    @Override
-    public String getIconClassName() {
-        return icon.getIconClassName();
     }
 
     protected FolderIcon newDefaultFolderIcon() {


### PR DESCRIPTION
## [JENKINS-74990] Prevent stack overflow / Revert "Add icons for search"

[JENKINS-74990](https://issues.jenkins.io/browse/JENKINS-74990) notes that when a folder definition includes the XML:

```
<icon class="jenkins.branch.MetadataActionFolderIcon" plugin="branch-api@2.1200.v4b_a_3da_2eb_db_4">
  <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../.."/>
</icon>
```

then the 6.971.v9a_984fd08864 release of the plugin reports a stack overflow.

Revert the change so that there is enough time for diagnosis without the pressure of users reporting and diagnosing bugs.

Change has no tests because I wanted to implement a quick solution so that users won't be affected.

This reverts commit c9fe2ab306a977d2946c6d44724fc062fd5391b7.

### Testing done

Confirmed that the issue is visible without this change and is resolved with this change.  Details in [JENKINS-74990](https://issues.jenkins.io/browse/JENKINS-74990) 

### Proposed changelog entries

*  [JENKINS-74990] Prevent stack overflow on folders with MetadataActionFolderIcon

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Appropriate autotests or explanation to why this change has no tests
