### PR TITLE
make side-panel sticky on configure screen

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
       <script src="${resURL}/jsbundles/section-to-sidebar-items.js" type="text/javascript" defer="true" />
     </l:header>
 
-    <l:side-panel>
+    <l:side-panel sticky="true">
       <l:app-bar title="${%Configuration}"/>
       <div id="tasks" />
     </l:side-panel>


### PR DESCRIPTION
to be in sync with the configure screen of jobs

I think this is helpful especially for multibranch or org folders that have longer config screens.
<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Make sidepanel sticky in folder configuration
* ...

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
