### PR TITLE
Support groups for Command Palette

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>2.496-SNAPSHOT</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
     <useBeta>true</useBeta> <!-- needed for Jenkins.MANAGE support -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>2.496-SNAPSHOT</jenkins.version>
+    <jenkins.version>2.499-rc36166.d7b_7d6388deb_</jenkins.version>
     <no-test-jar>false</no-test-jar>
     <hpi.compatibleSinceVersion>5.2</hpi.compatibleSinceVersion>
     <useBeta>true</useBeta> <!-- needed for Jenkins.MANAGE support -->

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -727,7 +727,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
 
     @Override
     public SearchGroup getSearchGroup() {
-        return SearchGroup.get(SearchGroup.JobSearchGroup.class);
+        return SearchGroup.get(SearchGroup.ItemSearchGroup.class);
     }
 
     /**

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -102,6 +102,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ProjectNamingStrategy;
 import jenkins.model.TransientActionFactory;
+import jenkins.search.SearchGroup;
 import jenkins.security.stapler.StaplerNotDispatchable;
 import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
@@ -139,7 +140,7 @@ import org.springframework.security.access.AccessDeniedException;
  */
 @SuppressWarnings({"unchecked", "rawtypes"}) // mistakes in various places
 @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE") // https://github.com/spotbugs/spotbugs/issues/1539
-public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractItem implements TopLevelItem, ItemGroup<I>, ModifiableViewGroup, StaplerFallback, ModelObjectWithChildren, StaplerOverridable {
+public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractItem implements TopLevelItem, ItemGroup<I>, ModifiableViewGroup, StaplerFallback, ModelObjectWithChildren, StaplerOverridable, SearchItem {
 
     /**
      * Our logger.
@@ -722,6 +723,11 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
                 return AbstractFolder.this;
             }
         });
+    }
+
+    @Override
+    public SearchGroup getSearchGroup() {
+        return SearchGroup.get(SearchGroup.JobSearchGroup.class);
     }
 
     /**


### PR DESCRIPTION
Adds support for grouping via https://github.com/jenkinsci/jenkins/pull/10252. Previously folders would appear under the 'Other' group, rather than 'Items'.

**Before**
<img width="668" alt="image" src="https://github.com/user-attachments/assets/9b6e5af3-ff84-42c4-9ecd-c22cc28c4f1a" />

**After**
<img width="659" alt="image" src="https://github.com/user-attachments/assets/d890fc9b-d16f-4fc6-a517-8aca7a3806d5" />

### Proposed changelog entries

* Support groups for Command Palette

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
