### PR TITLE
Log loadChildren failure stacktrace at FINE level, keep WARNING level log oneliner

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -386,7 +386,11 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
                 configurations.put(key.apply(item), item);
             } catch (Exception e) {
                 File finalEffectiveSubdir = effectiveSubdir;
-                LOGGER.log(Level.WARNING, e, () -> "could not load " + finalEffectiveSubdir);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, e, () -> "could not load " + finalEffectiveSubdir);
+                } else {
+                    LOGGER.log(Level.WARNING, "could not load " + finalEffectiveSubdir + " due to " + e);
+                }
             }
         }
 


### PR DESCRIPTION
Whenever a child job fails to load, a warning with the full stack trace was being logged. We noticed this issue in the CloudBees High Availability product, where a job created by one replica may not be fully ready before another replica attempts to load it. This warning is commonly seen when nested pipeline jobs are created in tests or via scripts, but it is actually harmless.

This PR updates the logging behavior to make the WARNING level message a concise one-liner that still includes the exception cause. If a full stack trace is needed, it can be obtained by enabling the FINE logging level.

**Testing**

Manual testing to verify the logging is correctly happening
* WARNING level
   ```
   2025-03-20 12:34:26.820+0000 [id=116]	WARNING	c.c.h.p.folder.AbstractFolder#loadChildren: could not load /.../plugin/target/tmp/j h15281053432078939224/jobs/folder/jobs/p due to java.io.FileNotFoundException: Could not find configuration file /.../plugin/target/tmp/j h15281053432078939224/jobs/folder/jobs/p/config.xml
   ```
* FINE level
  ```
  2025-03-20 12:36:25.271+0000 [id=116]	FINE	c.c.h.p.folder.AbstractFolder#loadChildren: could not load /.../plugin/target/tmp/j h6079388103679385184/jobs/folder/jobs/p
  java.io.FileNotFoundException: Could not find configuration file /.../plugin/target/tmp/j h6079388103679385184/jobs/folder/jobs/p/config.xml
	  at PluginClassLoader for cloudbees-folder//com.cloudbees.hudson.plugins.folder.AbstractFolder.loadChildren(AbstractFolder.java:370)
	  at PluginClassLoader for cloudbees-folder//com.cloudbees.hudson.plugins.folder.AbstractFolder.onLoad(AbstractFolder.java:479)
	  at PluginClassLoader for cloudbees-folder//com.cloudbees.hudson.plugins.folder.Folder.onLoad(Folder.java:117)
	  at hudson.model.Items.load(Items.java:376)
	  ....
	  ....
  ```
### Proposed changelog entries

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
