### PR TITLE
Avoid unnecessary writes to `ChildNameGenerator#CHILD_NAME_FILE`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
@@ -378,7 +378,15 @@ public abstract class ChildNameGenerator<P extends AbstractFolder<I>, I extends 
             if (Files.notExists(itemPath)) {
                 Files.createDirectories(itemPath);
             }
-            Files.writeString(nameFile.toPath(), name, StandardCharsets.UTF_8);
+            String existingName;
+            if (Files.exists(nameFile.toPath())) {
+                existingName = Files.readString(nameFile.toPath(), StandardCharsets.UTF_8);
+            } else {
+                existingName = null;
+            }
+            if (existingName == null || !existingName.equals(name)) {
+                Files.writeString(nameFile.toPath(), name, StandardCharsets.UTF_8);
+            }
         } catch (IOException e) {
             // Unfortunately not all callers of this method throw IOException, so we need to go unchecked
             throw new UncheckedIOException("Failed to load " + name + " as could not write " + nameFile, e);


### PR DESCRIPTION
Noticed this minor inefficiency while reading the code. We always write to `ChildNameGenerator#CHILD_NAME_FILE` when loading a folder, even when the existing value is up-to-date. This can result in an update to its metadata (e.g., `mtime`, the last modification time) in the file system, even if the content is the same, which in return can require additional I/O to update the inode or journal. Instead we write the value only when necessary.

### Testing done

Stepped through the following cases in the debugger:

- Creating a folder for the first time (wrote the file as expected)
- Renaming a folder (wrote the file as expected)
- Loaded an existing folder (did not write the file as expected, but wrote it unnecessarily before this PR)

### Proposed changelog entries

Avoid unnecessary disk writes while loading folders.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
