### PR TITLE
Prepare to eventually remove `ChildNameGenerator#CHILD_NAME_FILE`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -378,6 +378,13 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
                     }
                 }
                 name = childNameGenerator.writeItemName(parent, item, effectiveSubdir, childName);
+                String computedName = childNameGenerator.itemNameFromItem(parent, item);
+                if (computedName == null) {
+                    computedName = subdir.getName();
+                }
+                if (!computedName.equals(name)) {
+                    throw new IllegalStateException("Computed name '" + computedName + "' does not match name read from file '" + name + "'");
+                }
                 if (item instanceof AbstractItem) {
                     var abstractItem = (AbstractItem) item;
                     if (itemFromDir != null && !legacyName.equals(name) && abstractItem.getDisplayNameOrNull() == null) {
@@ -400,7 +407,15 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
 
     @Override
     public String getItemName(File dir, I item) {
-        return childNameGenerator().readItemName(dir);
+        String name = childNameGenerator().readItemName(dir);
+        String computedName = childNameGenerator().itemNameFromItem(this, item);
+        if (computedName == null) {
+            computedName = dir.getName();
+        }
+        if (!computedName.equals(name)) {
+            throw new IllegalStateException("Computed name '" + computedName + "' does not match name read from file '" + name + "'");
+        }
+        return name;
     }
 
     protected final I itemsPut(String name, I item) {

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -383,7 +383,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
                     computedName = subdir.getName();
                 }
                 if (!computedName.equals(name)) {
-                    throw new IllegalStateException("Computed name '" + computedName + "' does not match name read from file '" + name + "'");
+                    throw new IllegalStateException("Computed name '" + computedName + "' does not match name written to file '" + name + "'");
                 }
                 if (item instanceof AbstractItem) {
                     var abstractItem = (AbstractItem) item;


### PR DESCRIPTION
`ChildNameGenerator#CHILD_NAME_FILE` introduces unnecessary complexity and has been at the scene of several concurrency issues, so we would like to eventually remove it. But it is not completely clear if it is still needed. I stepped through a few scenarios in the debugger in `cloudbees-folder`, `branch-api`, and `workflow-multibranch`, and I couldn't find a case where it was needed. But my confidence is low that I have fully understood the problem.

If there are no calls to `readItemName`, then it is pointless to write the item name and we can also remove all calls to `writeItemName`. So what would it take to remove all calls to `readItemName`? This PR computes the item name a new way, without relying on `readItemName`, and then calls `readItemName` to confirm that the results are the same. If the results are not the same, an `IllegalStateException` is thrown.

The idea is that if this change is delivered and no complaints occur, we can be reasonably sure that the new way of computing the item name does not introduce a regression. We can then delete the calls to `readItemName`, since we will be sure the replacement yields the same results. And as a result of deleting all calls to `readItemName`, we can also delete all calls to `writeItemName` as well, and the implementations of `readItemName` and `writeItemName` themselves.

If, on the other hand, a complaint does occur, then we will understand precisely the use case that needs to be tested before we can completely eliminate `CHILD_NAME_FILE`.

### Proposed changelog entries

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
