### PR TITLE
Migrate from `RestartableJenkinsRule` to `JenkinsSessionRule`

### DIFF
--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
@@ -57,8 +57,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import net.sf.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runners.model.Statement;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.StaplerRequest2;
 
@@ -78,7 +77,7 @@ import static org.junit.Assert.assertEquals;
 public class ChildNameGeneratorAltTest {
 
     @Rule
-    public RestartableJenkinsRule r = new RestartableJenkinsRule();
+    public JenkinsSessionRule r = new JenkinsSessionRule();
 
     /**
      * Given: a computed folder
@@ -86,11 +85,9 @@ public class ChildNameGeneratorAltTest {
      * Then: mangling gets applied
      */
     @Test
-    public void createdFromScratch() {
-        r.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                ComputedFolderImpl instance = r.j.jenkins.createProject(ComputedFolderImpl.class, "instance");
+    public void createdFromScratch() throws Throwable {
+        r.then(j -> {
+                ComputedFolderImpl instance = j.createProject(ComputedFolderImpl.class, "instance");
                 instance.assertItemNames(0);
                 instance.recompute(Result.SUCCESS);
                 instance.assertItemNames(1);
@@ -106,23 +103,19 @@ public class ChildNameGeneratorAltTest {
                 );
                 instance.recompute(Result.SUCCESS);
                 checkComputedFolder(instance, 2);
-            }
         });
-        r.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                TopLevelItem i = r.j.jenkins.getItem("instance");
+        r.then(j -> {
+                TopLevelItem i = j.jenkins.getItem("instance");
                 assertThat("Item loaded from disk", i, instanceOf(ComputedFolderImpl.class));
                 ComputedFolderImpl instance = (ComputedFolderImpl) i;
                 checkComputedFolder(instance, 0);
-                r.j.jenkins.reload();
-                i = r.j.jenkins.getItem("instance");
+                j.jenkins.reload();
+                i = j.jenkins.getItem("instance");
                 assertThat("Item loaded from disk", i, instanceOf(ComputedFolderImpl.class));
                 instance = (ComputedFolderImpl) i;
                 checkComputedFolder(instance, 0);
                 instance.doReload();
                 checkComputedFolder(instance, 0);
-            }
         });
     }
 

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorRecTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorRecTest.java
@@ -52,12 +52,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import net.sf.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runners.model.Statement;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.StaplerRequest2;
 
@@ -77,7 +75,7 @@ import static org.junit.Assert.assertEquals;
 public class ChildNameGeneratorRecTest {
 
     @Rule
-    public RestartableJenkinsRule r = new RestartableJenkinsRule();
+    public JenkinsSessionRule r = new JenkinsSessionRule();
 
     /**
      * Given: a computed folder
@@ -85,11 +83,9 @@ public class ChildNameGeneratorRecTest {
      * Then: mangling gets applied
      */
     @Test
-    public void createdFromScratch() {
-        r.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                ComputedFolderImpl instance = r.j.jenkins.createProject(ComputedFolderImpl.class, "instance");
+    public void createdFromScratch() throws Throwable {
+        r.then(j -> {
+                ComputedFolderImpl instance = j.createProject(ComputedFolderImpl.class, "instance");
                 instance.assertItemNames(0);
                 instance.recompute(Result.SUCCESS);
                 instance.assertItemNames(1);
@@ -105,23 +101,19 @@ public class ChildNameGeneratorRecTest {
                 );
                 instance.recompute(Result.SUCCESS);
                 checkComputedFolder(instance, 2);
-            }
         });
-        r.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                TopLevelItem i = r.j.jenkins.getItem("instance");
+        r.then(j -> {
+                TopLevelItem i = j.jenkins.getItem("instance");
                 assertThat("Item loaded from disk", i, instanceOf(ComputedFolderImpl.class));
                 ComputedFolderImpl instance = (ComputedFolderImpl) i;
                 checkComputedFolder(instance, 0);
-                r.j.jenkins.reload();
-                i = r.j.jenkins.getItem("instance");
+                j.jenkins.reload();
+                i = j.jenkins.getItem("instance");
                 assertThat("Item loaded from disk", i, instanceOf(ComputedFolderImpl.class));
                 instance = (ComputedFolderImpl) i;
                 checkComputedFolder(instance, 0);
                 instance.doReload();
                 checkComputedFolder(instance, 0);
-            }
         });
     }
 

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolder2Test.java
@@ -41,38 +41,31 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 import org.jvnet.hudson.test.TestExtension;
 
 public class ComputedFolder2Test {
 
     @Rule
-    public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+    public JenkinsSessionRule rr = new JenkinsSessionRule();
 
     @Issue("JENKINS-42593")
     @Test
-    public void eventAfterRestart() {
-        rr.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                EventableFolder d = rr.j.jenkins.createProject(EventableFolder.class, "d");
+    public void eventAfterRestart() throws Throwable {
+        rr.then(j -> {
+                EventableFolder d = j.createProject(EventableFolder.class, "d");
                 d.add("one");
                 String log = ComputedFolderTest.doRecompute(d, Result.SUCCESS);
                 assertThat(log, d.getItems(), hasSize(equalTo(1)));
-            }
         });
-        rr.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                EventableFolder d = rr.j.jenkins.getItemByFullName("d", EventableFolder.class);
+        rr.then(j -> {
+                EventableFolder d = j.jenkins.getItemByFullName("d", EventableFolder.class);
                 assertNotNull(d);
                 assertThat(d.getItems(), hasSize(equalTo(1)));
                 d.add("two");
                 String log = ComputedFolderTest.doRecompute(d, Result.SUCCESS);
                 assertThat(log, d.getItems(), hasSize(equalTo(1)));
-            }
         });
     }
 


### PR DESCRIPTION
Migrate from deprecated functionality to non-deprecated equivalent.

### Proposed changelog entries

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
