### PR TITLE
Retain child item identity when using a `NameMangler`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -365,8 +365,8 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
             V itemFromDir;
             V item;
             String name;
-            item = itemFromDir = byDirName.get(childName);
             var legacyName = subdir.getName();
+            item = itemFromDir = byDirName.get(legacyName);
             try {
                 if (item == null) {
                     XmlFile xmlFile = Items.getConfigFile(subdir);

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorAltTest.java
@@ -69,6 +69,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 
 /**
@@ -120,8 +121,16 @@ public class ChildNameGeneratorAltTest {
                 assertThat("Item loaded from disk", i, instanceOf(ComputedFolderImpl.class));
                 instance = (ComputedFolderImpl) i;
                 checkComputedFolder(instance, 0);
+                var items = new ArrayList<>(instance.getItems());
                 instance.doReload();
                 checkComputedFolder(instance, 0);
+                var newItems = new ArrayList<>(instance.getItems());
+                // Check child items identity is preserved
+                assertThat("Items are the same", items, is(newItems));
+                for (int k = 0; k < items.size(); k++) {
+                    assertSame("Individual items must be the same", items.get(k), newItems.get(k));
+                }
+
             }
         });
     }


### PR DESCRIPTION
PR #376 caused every child to be recreated on reload, whereas the intent is to retain the object identity.

cf. https://github.com/jenkinsci/cloudbees-folder-plugin/pull/376#discussion_r2035617683 (thank you @basil)

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fix a regression causing all children to be recreated on folder reload when using a `NameMangler`

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
