### PR TITLE
Prepare for eventual removal of `ChildNameGenerator#ensureItemDirectory`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
@@ -219,14 +219,7 @@ public abstract class ChildNameGenerator<P extends AbstractFolder<I>, I extends 
         }
         File newSubdir = parent.getRootDirFor(dirName);
         if (!legacyName.equals(dirName)) {
-            if (!newSubdir.exists()) {
-                LOGGER.log(Level.INFO, () -> "Moving " + legacyDir + " to " + newSubdir + " in accordance with folder naming rules");
-                if (!legacyDir.renameTo(newSubdir)) {
-                    throw new IOException("Failed to move " + legacyDir + " to " + newSubdir);
-                }
-            } else {
-                throw new IOException("Cannot move " + legacyDir + " to " + newSubdir + " as it already exists");
-            }
+            throw new IllegalStateException("Actual directory name '" + legacyName + "' does not match expected name '" + dirName + "'");
         }
         return newSubdir;
     }


### PR DESCRIPTION
As with #484, I am pretty sure that this is dead code, and I would like to delete it, but I am not entirely sure I have understood the problem. So planning to deploy this to Jenkins users with an assertion that we are never hitting this code path, and if nobody complains that the assertion is firing then I will feel more confident that this code can be deleted.

### Testing done

Will run BOM.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
