### PR TITLE
Remove useless annotation

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
@@ -24,7 +24,6 @@
 
 package com.cloudbees.hudson.plugins.folder.computed;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import java.util.zip.GZIPInputStream;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
@@ -235,7 +234,6 @@ public class FolderComputation<I extends TopLevelItem> extends Actionable implem
         return new File(folder.getComputationDir(), "events.log");
     }
 
-    @WithBridgeMethods(TaskListener.class)
     @NonNull
     public synchronized StreamTaskListener createEventsListener() {
         File eventsFile = getEventsFile();


### PR DESCRIPTION
The use of this annotation dates back to #86, but the bridge method is not actually present today because of the lack of `bridge-method-injector` during the build process. Since the intervening 8 years have clearly demonstrated that the bridge method is not actually needed, remove the useless annotation rather than adding `bridge-method-injector` to the build.

### Testing done

Dumped the bytecode of the class with `javap` before and after this change and verified it was the same (i.e., no bridge method both before and after, as expected).

### Proposed changelog entries

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
