### PR TITLE
remove usages of commons-lang from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
   <dependencies>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>ionicons-api</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,6 @@
   <dependencies>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>commons-lang3-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
       <artifactId>ionicons-api</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
@@ -46,7 +46,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.TransientActionFactory;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Provides a way for a {@link ComputedFolder} to break the association between the directory names on disk
@@ -294,7 +293,7 @@ public abstract class ChildNameGenerator<P extends AbstractFolder<I>, I extends 
         File nameFile = new File(directory, CHILD_NAME_FILE);
         if (nameFile.isFile()) {
             try {
-                childName = Objects.toString(StringUtils.trimToNull(Files.readString(nameFile.toPath(), StandardCharsets.UTF_8)), directory.getName());
+                childName = Objects.toString(Util.fixEmptyAndTrim(Files.readString(nameFile.toPath(), StandardCharsets.UTF_8)), directory.getName());
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, () -> "Could not read "+ nameFile + ", assuming child name is " + directory.getName());
             }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
@@ -39,13 +39,14 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Map;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.TransientActionFactory;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Provides a way for a {@link ComputedFolder} to break the association between the directory names on disk
@@ -293,7 +294,7 @@ public abstract class ChildNameGenerator<P extends AbstractFolder<I>, I extends 
         File nameFile = new File(directory, CHILD_NAME_FILE);
         if (nameFile.isFile()) {
             try {
-                childName = StringUtils.defaultString(StringUtils.trimToNull(Files.readString(nameFile.toPath(), StandardCharsets.UTF_8)), directory.getName());
+                childName = Objects.toString(StringUtils.trimToNull(Files.readString(nameFile.toPath(), StandardCharsets.UTF_8)), directory.getName());
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, () -> "Could not read "+ nameFile + ", assuming child name is " + directory.getName());
             }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
@@ -36,7 +36,7 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
@@ -36,7 +36,6 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -107,19 +106,19 @@ public class PeriodicFolderTrigger extends Trigger<ComputedFolder<?>> {
         interval = interval.toLowerCase();
         if (interval.endsWith("h")) {
             units = TimeUnit.HOURS;
-            interval = StringUtils.removeEnd(interval, "h");
+            interval = interval.substring(0, interval.length() - 1);
         }
         if (interval.endsWith("m")) {
-            interval = StringUtils.removeEnd(interval, "m");
+            interval = interval.substring(0, interval.length() - 1);
         } else if (interval.endsWith("d")) {
             units = TimeUnit.DAYS;
-            interval = StringUtils.removeEnd(interval, "d");
+            interval = interval.substring(0, interval.length() - 1);
         } else if (interval.endsWith("ms")) {
             units = TimeUnit.SECONDS;
-            interval = StringUtils.removeEnd(interval, "ms");
+            interval = interval.substring(0, interval.length() - 1);
         } else if (interval.endsWith("s")) {
             units = TimeUnit.SECONDS;
-            interval = StringUtils.removeEnd(interval, "s");
+            interval = interval.substring(0, interval.length() - 1);
         }
         long value = 0;
         try {

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PseudoRun.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PseudoRun.java
@@ -71,7 +71,7 @@ public class PseudoRun<I extends TopLevelItem> extends Actionable implements Sta
      */
     @NonNull
     public String getTimestampString2() {
-        return Util.XS_DATETIME_FORMATTER.format(computation.getTimestamp());
+        return Util.XS_DATETIME_FORMATTER2.format(computation.getTimestamp().toInstant());
     }
 
     @CheckForNull

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorTest.java
@@ -618,13 +618,13 @@ public class ChildNameGeneratorTest {
 
     static CharSequence asJavaString(String rawString) {
         StringBuilder b = new StringBuilder();
-        rawString.codePoints().forEach(c -> {
+        for (char c : rawString.toCharArray()) {
             if (c >= 32 && c < 128) {
-                b.append(Character.toString(c));
+                b.append(c);
             } else {
-                b.append(String.format("\\u%04x", c));
+                b.append(String.format("\\u%04x", (int) c));
             }
-        });
+        }
         return b;
     }
 

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorTest.java
@@ -54,7 +54,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsSessionRule;

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildNameGeneratorTest.java
@@ -54,7 +54,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsSessionRule;
@@ -619,13 +618,13 @@ public class ChildNameGeneratorTest {
 
     static CharSequence asJavaString(String rawString) {
         StringBuilder b = new StringBuilder();
-        for (char c : rawString.toCharArray()) {
+        rawString.codePoints().forEach(c -> {
             if (c >= 32 && c < 128) {
-                b.append(c);
+                b.append(Character.toString(c));
             } else {
-                b.append("\\u").append(StringUtils.leftPad(Integer.toHexString(c & 0xffff), 4, '0'));
+                b.append(String.format("\\u%04x", c));
             }
-        }
+        });
         return b;
     }
 


### PR DESCRIPTION
To be able to remove commons-lang from core all direct and indirect usages must be replaced with commons-lang3 or native Java

- use XS_DATETIME_FORMATTER2 instead of deprecated XS_DATETIME_FORMATTER from core
- replaced commons-lang with native Java

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* remove usages of commons-lang from core

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
