### PR TITLE
Mistakes in `PeriodicFolderTrigger` handling of ms-scale times

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java
@@ -114,8 +114,8 @@ public class PeriodicFolderTrigger extends Trigger<ComputedFolder<?>> {
             units = TimeUnit.DAYS;
             interval = interval.substring(0, interval.length() - 1);
         } else if (interval.endsWith("ms")) {
-            units = TimeUnit.SECONDS;
-            interval = interval.substring(0, interval.length() - 1);
+            units = TimeUnit.MILLISECONDS;
+            interval = interval.substring(0, interval.length() - 2);
         } else if (interval.endsWith("s")) {
             units = TimeUnit.SECONDS;
             interval = interval.substring(0, interval.length() - 1);


### PR DESCRIPTION
https://github.com/jenkinsci/cloudbees-folder-plugin/pull/500#discussion_r2113189108 good catch @szjozsef though in fact this was using the wrong unit anyway, dating all the way back to https://github.com/jenkinsci/branch-api-plugin/commit/5e85b537e1ca543191967097fc25f00626f1e170, and it does not seem to matter since the minimum permitted interval is 1m and that is also the minimum offered in the GUI dropdown.