### PR TITLE
Remove `ChildNameGenerator#ensureItemDirectory`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -359,7 +359,6 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
             }
         }
         for (File subdir : subdirs) {
-            File effectiveSubdir = subdir;
             // Try to retain the identity of an existing child object if we can.
             V item = byDirName.get(subdir.getName());
             try {
@@ -367,7 +366,6 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
                     XmlFile xmlFile = Items.getConfigFile(subdir);
                     if (xmlFile.exists()) {
                         item = (V) xmlFile.read();
-                        effectiveSubdir = childNameGenerator.ensureItemDirectory(parent, item, subdir);
                     } else {
                         throw new FileNotFoundException("Could not find configuration file " + xmlFile.getFile());
                     }
@@ -379,8 +377,7 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
                 item.onLoad(parent, name);
                 configurations.put(key.apply(item), item);
             } catch (Exception e) {
-                File finalEffectiveSubdir = effectiveSubdir;
-                LOGGER.warning(() -> "could not load " + finalEffectiveSubdir + " due to " + e);
+                LOGGER.warning(() -> "could not load " + subdir + " due to " + e);
                 LOGGER.log(Level.FINE, null, e);
             }
         }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildNameGenerator.java
@@ -33,7 +33,6 @@ import hudson.model.ItemGroup;
 import hudson.model.JobProperty;
 import hudson.model.TopLevelItem;
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -183,29 +182,6 @@ public abstract class ChildNameGenerator<P extends AbstractFolder<I>, I extends 
             name = dirNameFromLegacy(parent, item.getName());
         }
         return name;
-    }
-
-    /**
-     * Ensures that the item is stored in the correct directory, and moves it if necessary.
-     *
-     * @param parent the parent of the given item.
-     * @param item the item to determine directory for.
-     * @param legacyDir The directory name that we are loading an item from.
-     * @return a reference to the (new) directory storing the item, and whether the item needs to be saved.
-     * @throws IOException In case something went wrong while setting up the expected result directory.
-     */
-    @NonNull
-    final File ensureItemDirectory(@NonNull P parent, @NonNull I item, @NonNull File legacyDir) throws IOException {
-        String legacyName = legacyDir.getName();
-        String dirName = dirNameFromItem(parent, item);
-        if (dirName == null) {
-            dirName = dirNameFromLegacy(parent, legacyName);
-        }
-        File newSubdir = parent.getRootDirFor(dirName);
-        if (!legacyName.equals(dirName)) {
-            throw new IllegalStateException("Actual directory name '" + legacyName + "' does not match expected name '" + dirName + "'");
-        }
-        return newSubdir;
     }
 
     /**


### PR DESCRIPTION
Completes the work started in #487 by completely removing any references to `ChildNameGenerator#ensureItemDirectory`. Nobody ever complained about us hitting the assertion, so this must be dead code that can be safely removed.