### PR TITLE
Restore "Enable" button

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/view-index-top.jelly
@@ -54,7 +54,14 @@ THE SOFTWARE.
       <!-- for now, quietly omit the option -->
     </j:when>
     <j:when test="${it.disabled}">
-      <div id="disabled-message" class="warning">${%disabled(it.pronoun)}</div>
+      <div class="warning" id="disabled-message">
+        <form method="post" id='enable-project' action="${rootURL}/${it.url}enable">
+          ${%disabled(it.pronoun)}<st:nbsp/>
+          <l:hasPermission permission="${it.CONFIGURE}">
+            <f:submit value="${%Enable}"/>
+          </l:hasPermission>
+        </form>
+      </div>
     </j:when>
   </j:choose>
   <!-- give actions a chance to contribute summary item -->


### PR DESCRIPTION
#419 removed the "Enable button" without a justification: Core did not remove that button from Freestyle projects in #9287, so aligning with core behavior shouldn't remove it either.

Freestyle for comparison:
<img width="1384" height="438" alt="Screenshot 2025-08-16 at 12 22 52" src="https://github.com/user-attachments/assets/d08c96ca-15f6-4a5e-88ea-d01a2eef0e03" />

Folder before (after #433):
<img width="1438" height="455" alt="Screenshot 2025-08-16 at 12 24 05" src="https://github.com/user-attachments/assets/6750488b-56a5-4127-af6a-131f9b883122" />

Folder after:
<img width="1581" height="486" alt="Screenshot 2025-08-16 at 12 28 58" src="https://github.com/user-attachments/assets/ef0c39c8-4331-4db6-86cf-b6921e02256c" />

Manually tested by clicking the button on an empty MBPL in `hpi:run` and it worked.

### Proposed changelog entries

* Allow enabling certain folders, like Multibranch Pipelines, from their main page again, if they're disabled.

<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
