### PR TITLE
Add SaveAllJobsAction to save all jobs in folder after copy

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/Folder.java
@@ -68,6 +68,9 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.verb.POST;
 
+import com.cloudbees.hudson.plugins.folder.SaveAllJobsAction;
+
+
 /**
  * A mutable folder.
  */
@@ -414,7 +417,7 @@ public class Folder extends AbstractFolder<TopLevelItem> implements DirectlyModi
     @Override public void remove(TopLevelItem item) throws IOException, IllegalArgumentException {
         items.remove(item.getName());
     }
-
+    
     @Extension
     public static class DescriptorImpl extends AbstractFolderDescriptor {
 

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/SaveAllJobsAction.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/SaveAllJobsAction.java
@@ -1,0 +1,44 @@
+package com.cloudbees.hudson.plugins.folder;
+
+import hudson.model.Action;
+import hudson.model.Job;
+import java.io.IOException;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+public class SaveAllJobsAction implements Action {
+
+    private final Folder folder;
+
+    public SaveAllJobsAction(Folder folder) {
+        this.folder = folder;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return "save.png"; // small save icon
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Save All Jobs";
+    }
+
+    @Override
+    public String getUrlName() {
+        return "save-all-jobs";
+    }
+
+    // Called when the form is submitted
+    public void doIndex(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        doSaveAll();
+        rsp.sendRedirect2("../"); // redirect back to folder page after saving
+    }
+
+    // Actual saving logic
+    public void doSaveAll() throws IOException {
+        for (Job<?, ?> job : folder.getAllJobs()) {
+            job.save();
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/SaveAllJobsAction/index.jelly
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/SaveAllJobsAction/index.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+  <l:layout title="Save All Jobs">
+    <l:main-panel>
+      <h1>Save All Jobs in Folder</h1>
+      <!-- POST to the action root so Stapler invokes doIndex() -->
+      <f:form method="post" action=".">
+        <f:submit value="Save All Jobs"/>
+      </f:form>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/SaveAllJobsActionFactory.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/SaveAllJobsActionFactory.java
@@ -1,0 +1,21 @@
+package com.cloudbees.hudson.plugins.folder;
+
+import hudson.Extension;
+import hudson.model.Action;
+import jenkins.model.TransientActionFactory;
+import java.util.Collection;
+import java.util.Collections;
+
+@Extension
+public class SaveAllJobsActionFactory extends TransientActionFactory<Folder> {
+    
+    @Override
+    public Class<Folder> type() {
+        return Folder.class;
+    }
+
+    @Override
+    public Collection<? extends Action> createFor(Folder target) {
+        return Collections.singletonList(new SaveAllJobsAction(target));
+    }
+}

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderTest.java
@@ -29,6 +29,7 @@ import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric;
 import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
 import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainCredentials;
+import com.cloudbees.hudson.plugins.folder.SaveAllJobsAction;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
 import org.htmlunit.html.*;
@@ -398,6 +399,19 @@ public class FolderTest {
         f.addAction(a);
         assertNotNull(f.getAction(WhoAmI.class));
     }
+
+    @Test public void testSaveAllJobsActionAppears() throws Exception {
+        Folder f = createFolder();
+        SaveAllJobsAction action = new SaveAllJobsAction(f);
+
+        // Check action is not null
+        assertNotNull(action);
+
+        // Check URL mapping and display name
+        assertEquals("save-all-jobs", action.getUrlName());
+        assertEquals("Save All Jobs", action.getDisplayName());
+    }
+
     
     @Issue("JENKINS-32487")
     @Test public void shouldAssignPropertyOwnerOnCreationAndReload() throws Exception {


### PR DESCRIPTION
### Summary
This PR introduces a SaveAllJobsAction that allows saving all jobs in a folder after copying, improving usability and preventing unsaved job issues.

### Implementation
- Added SaveAllJobsAction.java using TransientActionFactory
- Added index.jelly for UI button
- Added unit tests for the new action
- Fixed form post URL to avoid 404 errors

### Testing
- Verified manually via local Jenkins
- `mvn clean test` passes with no failures

Fixes JENKINS-20003