### PR TITLE
Inadequate error reporting from `ChildLoader`

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
@@ -91,7 +91,12 @@ public abstract class ChildLoader implements ExtensionPoint {
             item.onLoad(parent, name);
             return item;
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "could not load " + subdir, e);
+            if (e instanceof FileNotFoundException && !LOGGER.isLoggable(Level.FINE)) {
+                // commonplace error from missing config.xml, avoid log spam unless FINE is enabled anyway
+                LOGGER.warning(() -> "could not load " + subdir + " due to " + e);
+            } else {
+                LOGGER.log(Level.WARNING, "could not load " + subdir, e);
+            }
             return null;
         }
     }


### PR DESCRIPTION
While debugging an error related to #518 I noticed that Jenkins was by default printing a single-line warning

```
WARNING	c.c.h.plugins.folder.ChildLoader#loadItem: could not load …/jobs/xxx due to java.io.IOException: Unable to read …/jobs/xxx/config.xml
```

which is not exactly helpful for diagnosis! With this patch you can see that the full stack trace does in fact _end_ with

```
…
Caused: java.io.IOException: Unable to read …/jobs/xxx/config.xml
	at hudson.XmlFile.read(XmlFile.java:167)
	at PluginClassLoader for cloudbees-folder//com.cloudbees.hudson.plugins.folder.ChildLoader.loadItem(ChildLoader.java:82)
…
```

but you can also see the actual error as processed by XStream.

The problem actually dates to #475 by @gbhat618. In that case the stack trace was uninteresting, but clearly it overshot the goal.
