### PR TITLE
[8 year old bug] allow to dispatch more than 5 tasks on multicore CPU

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ThrottleComputationQueueTaskDispatcher.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/ThrottleComputationQueueTaskDispatcher.java
@@ -56,8 +56,8 @@ public class ThrottleComputationQueueTaskDispatcher extends QueueTaskDispatcher 
      */
     static int LIMIT = Math.max(1,
             Math.min(
-                    Integer.getInteger(ThrottleComputationQueueTaskDispatcher.class.getName() + ".LIMIT", 5),
-                    Runtime.getRuntime().availableProcessors() * 4
+                    Integer.getInteger(ThrottleComputationQueueTaskDispatcher.class.getName() + ".LIMIT", 16),
+                    Runtime.getRuntime().availableProcessors() * 2
             )
     );
     /**


### PR DESCRIPTION
Hello,

Could I have a second pair of eyes on this 8 year old code that looks very buggy to me?

I am experiencing regular issues with Jenkins indexing taking very long, with the message `indexing at maximum capacity`.

We have some large repos with 100+ branches and some small repos with few branches (it's all multibranch pipeline with one build per branch). 
Indexing can take hours when moving/renaming/onboarding many repos and/or many branches. It's incredibly slow.
Moving a few repos can take many minutes for not much. I appreciate that Jenkins may need to clone every branch but it shouldn't take that long on a physical server with modern CPU and DISK.

I've been investigating the issue and that brought me to this line of code.
It seems that the indexing is controlled by this 8 year old code `min(5, cpu*4)`, basically the result is always 5.  (throttle to 5 tasks per second if I understand well).

This doesn't make any sense.
I am honestly wondering if the whole thing is a typo and the original developer meant to write `max(5, cpu*4)`, which would make more sense at the time when desktops had 2-8 cores and servers had 20-40 cores. (However this would be too large on modern servers with hundreds of cores).

**What do you think?**

In the interest of getting jenkins to a better working state and because I had to make a code change to be able to raise a ticket. I think this can be safely raised to min(16, cpu*2)`.

Regards.

### Proposed changelog entries

* Entry 1: allow jenkins to dispatch more than 5 tasks on multicore CPU

- [ ] ~~JIRA issue is well described~~ happy to discuss whether this warrants a larger JIRA, changelog and more discussion.
- [ ] ~~Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).~~
- [X] ~~Appropriate autotests or explanation to why this change has no tests~~  I think this trivial value is not covered by tests.
