### PR TITLE
Fix "New Item" sidebar URL when browsing a folder view

### DIFF
--- a/src/main/resources/com/cloudbees/hudson/plugins/folder/Folder/tasks-create.jelly
+++ b/src/main/resources/com/cloudbees/hudson/plugins/folder/Folder/tasks-create.jelly
@@ -24,5 +24,9 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:set var="url" value="${h.getNearestAncestorUrl(request2,it)}"/>
-  <l:task icon="icon-new-package icon-md" href="${url}/newJob" title="${%newJob(it.newPronoun)}" permission="${it.CREATE}" />
+  <j:set var="newJobUrl" value="${h.getNearestAncestorUrl(request2, view)}"/>
+  <j:if test="${newJobUrl == null}">
+    <j:set var="newJobUrl" value="${url}"/>
+  </j:if>
+  <l:task icon="icon-new-package icon-md" href="${newJobUrl}/newJob" title="${%newJob(it.newPronoun)}" permission="${it.CREATE}" />
 </j:jelly>


### PR DESCRIPTION
### Problem

With the Folders plugin, the sidebar "New Item" link is rendered from `Folder/tasks-create.jelly` using `getNearestAncestorUrl(request, folder)`, which resolves to the folder URL only (e.g. `job/myfolder/`). When the user is on a non-default view inside that folder (e.g. `job/myfolder/view/my_view/`), the link incorrectly points to `.../newJob` under the folder root instead of `.../view/my_view/newJob`.

### Solution

Compute the link prefix from the current **View** when the Jelly context exposes the `view` variable (as set by Jenkins core’s `View/index.jelly` before the side panel is rendered), and fall back to the folder URL when that is not available.

### Testing

- Manual: create a folder, add a non-primary list view, open that view, click "New Item" in the sidebar and confirm the URL includes `view/<name>/`.
- Regression: open the folder’s primary/default view and confirm "New Item" still works.

### Proposed changelog entries

* Fix sidebar "New Item" URL when a folder view other than the primary view is selected.