### PR TITLE
Move item dirs without `config.xml` aside; do not warn about them on every startup

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java
@@ -335,7 +335,6 @@ public abstract class AbstractFolder<I extends TopLevelItem> extends AbstractIte
      * @param <V>        the child type.
      * @return a map of the children keyed by the generated keys.
      */
-    // TODO replace with ItemGroupMixIn.loadChildren once baseline core has JENKINS-41222 merged
     public static <K, V extends TopLevelItem> Map<K, V> loadChildren(AbstractFolder<V> parent, File modulesDir,
                                                              Function<? super V, ? extends K> key) {
         return ExtensionList.lookupFirst(ChildLoader.class).loadChildren(parent, modulesDir, key);

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
@@ -89,16 +89,16 @@ public abstract class ChildLoader implements ExtensionPoint {
                 } else {
                     var subdirP = subdir.toPath();
                     try {
-                    if (Files.getLastModifiedTime(subdirP).toInstant().isBefore(Instant.now().minus(SystemProperties.getDuration(GRACE_PERIOD_PROP, Duration.ofDays(1))))) {
-                        var brokenChildrenDir = parent.getRootDir().toPath().resolve("broken-children");
-                        var brokenChildDir = brokenChildrenDir.resolve(subdirP.getFileName());
-                        if (!Files.exists(brokenChildDir)) {
-                            Files.createDirectories(brokenChildrenDir);
-                            Files.move(subdirP, brokenChildDir);
-                            LOGGER.warning(() -> xmlFile + " did not exist; moved " + subdirP + " to " + brokenChildDir + " for analysis");
-                            return null;
+                        if (Files.getLastModifiedTime(subdirP).toInstant().isBefore(Instant.now().minus(SystemProperties.getDuration(GRACE_PERIOD_PROP, Duration.ofDays(1))))) {
+                            var brokenChildrenDir = parent.getRootDir().toPath().resolve("broken-children");
+                            var brokenChildDir = brokenChildrenDir.resolve(subdirP.getFileName());
+                            if (!Files.exists(brokenChildDir)) {
+                                Files.createDirectories(brokenChildrenDir);
+                                Files.move(subdirP, brokenChildDir);
+                                LOGGER.warning(() -> xmlFile + " did not exist; moved " + subdirP + " to " + brokenChildDir + " for analysis");
+                                return null;
+                            }
                         }
-                    }
                     } catch (IOException x) {
                         LOGGER.log(Level.WARNING, null, x);
                     }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
@@ -2,6 +2,7 @@ package com.cloudbees.hudson.plugins.folder;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.ExtensionPoint;
+import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.Item;
 import hudson.model.Items;
@@ -88,21 +89,22 @@ public abstract class ChildLoader implements ExtensionPoint {
                     item = (V) xmlFile.read();
                 } else {
                     var subdirP = subdir.toPath();
+                    var gracePeriod = SystemProperties.getDuration(GRACE_PERIOD_PROP, Duration.ofDays(1));
                     try {
-                        if (Files.getLastModifiedTime(subdirP).toInstant().isBefore(Instant.now().minus(SystemProperties.getDuration(GRACE_PERIOD_PROP, Duration.ofDays(1))))) {
+                        if (Files.getLastModifiedTime(subdirP).toInstant().isBefore(Instant.now().minus(gracePeriod))) {
                             var brokenChildrenDir = parent.getRootDir().toPath().resolve("broken-children");
                             var brokenChildDir = brokenChildrenDir.resolve(subdirP.getFileName());
                             if (!Files.exists(brokenChildDir)) {
                                 Files.createDirectories(brokenChildrenDir);
                                 Files.move(subdirP, brokenChildDir);
-                                LOGGER.warning(() -> xmlFile + " did not exist; moved " + subdirP + " to " + brokenChildDir + " for analysis");
+                                LOGGER.warning(() -> xmlFile + " did not exist; moved " + subdir + " to " + brokenChildDir + " for analysis");
                                 return null;
                             }
                         }
                     } catch (IOException x) {
-                        LOGGER.log(Level.WARNING, x, () -> xmlFile + " did not exist; failed to move " + subdirP + " aside for analysis");
+                        LOGGER.log(Level.WARNING, x, () -> xmlFile + " did not exist; failed to move " + subdir + " aside for analysis");
                     }
-                    LOGGER.warning(() -> xmlFile + " did not exist");
+                    LOGGER.warning(() -> xmlFile + " did not exist; " + Util.getTimeSpanString(gracePeriod.toMillis()) + " after last modification time " + subdir + " will be moved aside");
                     return null;
                 }
             }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
@@ -7,12 +7,16 @@ import hudson.model.Item;
 import hudson.model.Items;
 import hudson.model.TopLevelItem;
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.util.SystemProperties;
 
 public abstract class ChildLoader implements ExtensionPoint {
 
@@ -64,6 +68,8 @@ public abstract class ChildLoader implements ExtensionPoint {
         return byDirName;
     }
 
+    static final String GRACE_PERIOD_PROP = ChildLoader.class.getName() + ".missingConfigXmlGracePeriod";
+
     /**
      * Load a {@link TopLevelItem} from a given directory. The method attempts to read the item configuration, assign an
      * appropriate name to the item, and initialize it within the provided parent folder.
@@ -81,7 +87,23 @@ public abstract class ChildLoader implements ExtensionPoint {
                 if (xmlFile.exists()) {
                     item = (V) xmlFile.read();
                 } else {
-                    throw new FileNotFoundException("Could not find configuration file " + xmlFile.getFile());
+                    var subdirP = subdir.toPath();
+                    try {
+                    if (Files.getLastModifiedTime(subdirP).toInstant().isBefore(Instant.now().minus(SystemProperties.getDuration(GRACE_PERIOD_PROP, Duration.ofDays(1))))) {
+                        var brokenChildrenDir = parent.getRootDir().toPath().resolve("broken-children");
+                        var brokenChildDir = brokenChildrenDir.resolve(subdirP.getFileName());
+                        if (!Files.exists(brokenChildDir)) {
+                            Files.createDirectories(brokenChildrenDir);
+                            Files.move(subdirP, brokenChildDir);
+                            LOGGER.warning(() -> xmlFile + " did not exist; moved " + subdirP + " to " + brokenChildDir + " for analysis");
+                            return null;
+                        }
+                    }
+                    } catch (IOException x) {
+                        LOGGER.log(Level.WARNING, null, x);
+                    }
+                    LOGGER.warning(() -> xmlFile + " did not exist");
+                    return null;
                 }
             }
             String name = parent.childNameGenerator().itemNameFromItem(parent, item);
@@ -91,12 +113,8 @@ public abstract class ChildLoader implements ExtensionPoint {
             item.onLoad(parent, name);
             return item;
         } catch (Exception e) {
-            if (e instanceof FileNotFoundException && !LOGGER.isLoggable(Level.FINE)) {
-                // commonplace error from missing config.xml, avoid log spam unless FINE is enabled anyway
-                LOGGER.warning(() -> "could not load " + subdir + " due to " + e);
-            } else {
-                LOGGER.log(Level.WARNING, "could not load " + subdir, e);
-            }
+            LOGGER.log(Level.WARNING, "could not load " + subdir, e);
+            // Do not try to move to broken-children, because we do not know whether the error is transient.
             return null;
         }
     }

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/ChildLoader.java
@@ -100,7 +100,7 @@ public abstract class ChildLoader implements ExtensionPoint {
                             }
                         }
                     } catch (IOException x) {
-                        LOGGER.log(Level.WARNING, null, x);
+                        LOGGER.log(Level.WARNING, x, () -> xmlFile + " did not exist; failed to move " + subdirP + " aside for analysis");
                     }
                     LOGGER.warning(() -> xmlFile + " did not exist");
                     return null;

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/ChildLoaderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/ChildLoaderTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.hudson.plugins.folder;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import java.nio.file.Files;
+import java.time.Duration;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.junit.jupiter.FlagExtension;
+import org.jvnet.hudson.test.junit.jupiter.JenkinsSessionExtension;
+
+final class ChildLoaderTest {
+
+    @RegisterExtension private final JenkinsSessionExtension js = new JenkinsSessionExtension();
+
+    @RegisterExtension private static final FlagExtension<String> gracePeriodFlag = FlagExtension.systemProperty(ChildLoader.GRACE_PERIOD_PROP);
+
+    @Test void brokenChildren() throws Throwable {
+        js.then(r -> {
+            var bot = r.createProject(Folder.class, "top").createProject(Folder.class, "mid").createProject(FreeStyleProject.class, "bot");
+            r.buildAndAssertStatus(Result.SUCCESS, bot);
+            Files.delete(bot.getConfigFile().getFile().toPath());
+        });
+        js.then(r -> {
+            assertThat(r.jenkins.allItems(FreeStyleProject.class), emptyIterable());
+            assertThat(Files.exists(r.jenkins.getItemByFullName("top/mid").getRootDir().toPath().resolve("broken-children")), is(false));
+        });
+        System.setProperty(ChildLoader.GRACE_PERIOD_PROP, "1s");
+        Thread.sleep(Duration.ofSeconds(5).toMillis());
+        js.then(r -> {
+            assertThat(r.jenkins.allItems(FreeStyleProject.class), emptyIterable());
+            assertThat(Files.exists(r.jenkins.getItemByFullName("top/mid").getRootDir().toPath().resolve("broken-children/bot")), is(true));
+        });
+    }
+
+}


### PR DESCRIPTION
Amending #475 & #548. If `config.xml` is missing, printing an error every time Jenkins starts just means there will be log noise forever, unless and until an admin manually cleans it up. We may as well move such directories aside for possible troubleshooting and not produce any further log spam.

Doing this only when the child is at least a day old, to prevent improperly mangling child directories in weird NFS cases (say).

[CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-52162)