### PR TITLE
Only save folder configurations when their processing was succesful

### DIFF
--- a/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java
@@ -197,10 +197,12 @@ public class FolderComputation<I extends TopLevelItem> extends Actionable
             listener.finished(_result);
             listener.closeQuietly();
             result = _result;
-            try {
-                save();
-            } catch (IOException x) {
-                LOGGER.log(Level.WARNING, null, x);
+            if (result == Result.SUCCESS) {
+                try {
+                    save();
+                } catch (IOException x) {
+                    LOGGER.log(Level.WARNING, null, x);
+                }
             }
         }
     }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -647,6 +647,38 @@ class ComputedFolderTest {
         }
     }
 
+    @Test
+    void verifyFailingComputationDoesntSave() throws Exception {
+        FailingComputedFolder d = r.jenkins.createProject(FailingComputedFolder.class, "d");
+        d.setDisplayName("My Folder");
+
+        d.kids.add("A");
+        d.recompute(Result.SUCCESS);
+        // Contains the initial computation's timestamp
+        String computationAfterA = d.getComputation().getDataFile().asString();
+
+        // The computation performed above has a timestamp. The sleep below makes sure the next computation will store a different one.
+        TimeUnit.MILLISECONDS.sleep(1);
+        d.kids.add("B");
+        d.recompute(Result.SUCCESS);
+        // Contains the timestamp after the second computation
+        String computationAfterB = d.getComputation().getDataFile().asString();
+
+        // At least the timestamps in the saved files are different.
+        assertNotEquals(computationAfterA, computationAfterB);
+
+        // Ensures the folder computation file would be different from the previous one, if it was saved
+        TimeUnit.MILLISECONDS.sleep(1);
+        d.startFailing();
+        d.kids.add("C");
+        d.recompute(Result.FAILURE);
+        // If the computation file was saved, this would also be different from the previous.
+        // But because there's a failure, the file won't be touched and will be equal to after B.
+        String computationAfterC = d.getComputation().getDataFile().asString();
+
+        assertEquals(computationAfterB, computationAfterC);
+    }
+
     /**
      * Waits until Hudson finishes building everything, including those in the queue, or fail the test
      * if the specified timeout milliseconds is
@@ -1277,6 +1309,45 @@ class ComputedFolderTest {
             @Override
             public TopLevelItem newInstance(ItemGroup parent, String name) {
                 return new OneUndeletableChildComputedFolder(parent, name);
+            }
+        }
+    }
+
+    /**
+     * A folder that starts by working like a SampleComputedFolder
+     * but once it starts failing, it ceases to be able to compute its children.
+     * <br/>
+     * Useful to simulate network issues with folder-updating plugins.
+     */
+    public static class FailingComputedFolder extends SampleComputedFolder {
+
+        private boolean fail = false;
+
+        protected FailingComputedFolder(ItemGroup parent, String name) {
+            super(parent, name);
+        }
+
+        public void startFailing() {
+            fail = true;
+        }
+
+        @Override
+        protected void computeChildren(ChildObserver<FreeStyleProject> observer, TaskListener listener)
+                throws IOException, InterruptedException {
+            if (fail) {
+                throw new IOException("Simulating failures starting to happen on folder recomputation.");
+            } else {
+                super.computeChildren(observer, listener);
+            }
+        }
+
+        @SuppressWarnings("unused")
+        @TestExtension
+        public static class DescriptorImpl extends AbstractFolderDescriptor {
+
+            @Override
+            public TopLevelItem newInstance(ItemGroup parent, String name) {
+                return new FailingComputedFolder(parent, name);
             }
         }
     }

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/computed/ComputedFolderTest.java
@@ -657,7 +657,8 @@ class ComputedFolderTest {
         // Contains the initial computation's timestamp
         String computationAfterA = d.getComputation().getDataFile().asString();
 
-        // The computation performed above has a timestamp. The sleep below makes sure the next computation will store a different one.
+        // The computation performed above has a timestamp. The sleep below makes sure the next computation will store a
+        // different one.
         TimeUnit.MILLISECONDS.sleep(1);
         d.kids.add("B");
         d.recompute(Result.SUCCESS);


### PR DESCRIPTION
### Context
We use multibranch pipelines to get pipelines out of our GitLab instance's Merge Requests (which uses the [gitlab-branch-source-plugin](https://github.com/jenkinsci/gitlab-branch-source-plugin/) - I've also been proposing some related improvements there).

Sometimes, there are communication errors between our Jenkins instance and GitLab. When that happens, we see the gitlab-branch-source plugin saving inconsistent configurations.

Our understanding is that, in the cloudbees-folder-plugin, when the call for `folder.updateChildren(listener)` fails inside `FolderComputation#run()`, the `finally` block below it is reached. That triggers a `save()` call even in such failure cases, thus saving potentially inconsistent configs.

This change is an attempt at making updated folders only get saved when the computation is successful.

We are unsure about whether this may break other plugins, but still it seems odd to save the folder configurations when their computation fails. The code smells of an oversight for this marginal case (admittedly, if folder computation was always fully local, it wouldn't be expected to have failures doing it - but when remote resources such as GitLab are involved, such failures can become more frequent).

### Tests
Unit Tests are added to make sure the proposed behaviour is observed.

### Proposed changelog entries

* Internal: Only save the result of folder computations when they are successful

### Submitter checklist

- ~[ ] JIRA issue is well described~ No JIRA issue.
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests