### PR TITLE
Add draft ItemConfigurator support for Folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>

--- a/src/main/java/com/cloudbees/hudson/plugins/folder/FolderItemConfigurator.java
+++ b/src/main/java/com/cloudbees/hudson/plugins/folder/FolderItemConfigurator.java
@@ -1,0 +1,52 @@
+package com.cloudbees.hudson.plugins.folder;
+
+import hudson.Extension;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.ItemConfigurator;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import jenkins.model.Jenkins;
+import java.io.IOException;
+
+@Extension
+public class FolderItemConfigurator implements ItemConfigurator<Folder> {
+
+	@Override
+	public String getName() {
+		return "folder";
+	}
+
+	@Override
+	public Class<Folder> getTarget() {
+		return Folder.class;
+	}
+
+	@Override
+	public Folder configure(String name, CNode config, ConfigurationContext context) throws ConfiguratorException {
+		try {
+			Jenkins jenkins = Jenkins.get();
+			Folder folder = (Folder) jenkins.getItem(name);
+
+			if (folder == null) {
+				folder = jenkins.createProject(Folder.class, name);
+			}
+
+			Mapping mapping = config.asMapping();
+
+			if (mapping.containsKey("description")) {
+				folder.setDescription(mapping.getScalarValue("description"));
+			}
+
+			if (mapping.containsKey("displayName")) {
+				folder.setDisplayName(mapping.getScalarValue("displayName"));
+			}
+
+			folder.save();
+			return folder;
+
+		} catch (IOException e) {
+			throw new ConfiguratorException("Failed to configure folder: " + name, e);
+		}
+	}
+}

--- a/src/test/java/com/cloudbees/hudson/plugins/folder/FolderItemConfiguratorTest.java
+++ b/src/test/java/com/cloudbees/hudson/plugins/folder/FolderItemConfiguratorTest.java
@@ -1,0 +1,46 @@
+package com.cloudbees.hudson.plugins.folder;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class FolderItemConfiguratorTest {
+
+	@Rule
+	public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+	@Test
+	@ConfiguredWithCode("create-folder.yaml")
+	public void shouldCreateNewFolder() {
+		Folder folder = (Folder) Jenkins.get().getItem("team-alpha");
+
+		assertNotNull("Folder should have been created by JCasC", folder);
+		assertEquals("Team Alpha", folder.getDisplayName());
+		assertEquals("Description for Team Alpha", folder.getDescription());
+	}
+
+	@Test
+	public void shouldUpdateExistingFolder() throws Exception {
+		Folder existingFolder = j.jenkins.createProject(Folder.class, "team-beta");
+		existingFolder.setDescription("Old Description");
+		existingFolder.setDisplayName("Old Display Name");
+
+		ConfigurationAsCode.get().configure(
+			Objects.requireNonNull(getClass().getResource("update-folder.yaml")).toExternalForm()
+		);
+
+		Folder updatedFolder = (Folder) Jenkins.get().getItem("team-beta");
+
+		assertNotNull(updatedFolder);
+		assertEquals("Team Beta Updated", updatedFolder.getDisplayName());
+		assertEquals("New Description via JCasC", updatedFolder.getDescription());
+	}
+}

--- a/src/test/resources/com/cloudbees/hudson/plugins/folder/create-folder.yaml
+++ b/src/test/resources/com/cloudbees/hudson/plugins/folder/create-folder.yaml
@@ -1,0 +1,5 @@
+items:
+  - folder:
+      name: "team-alpha"
+      displayName: "Team Alpha"
+      description: "Description for Team Alpha"

--- a/src/test/resources/com/cloudbees/hudson/plugins/folder/update-folder.yaml
+++ b/src/test/resources/com/cloudbees/hudson/plugins/folder/update-folder.yaml
@@ -1,0 +1,5 @@
+items:
+  - folder:
+      name: "team-beta"
+      displayName: "Team Beta Updated"
+      description: "New Description via JCasC"


### PR DESCRIPTION
See  https://github.com/jenkinsci/configuration-as-code-plugin/pull/2881.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Please, ensure that the ticket has set the component 'cloudbees-folder-plugin'

 * We do not require JIRA issues for minor improvements, also we would appretiate it.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

Add a draft `FolderItemConfigurator` demonstrating how the proposed `ItemConfigurator` extension point can be implemented by the CloudBees Folder plugin to create and configure `Folder` instances through JCasC. As a proof of concept, this implementation supports configuring a folder's name, display name, and description, illustrating that the API can be extended beyond freestyle and pipeline jobs.

Example configuration:

```
items:
  - folder:
      name: "team-alpha-jobs"
      displayName: "Team Alpha"
      description: "All CI/CD jobs for Team Alpha"
```

### Proposed changelog entries



<!-- Comment: 
The changelogs will be integrated by the maintainers when a new version is release. Please, notice that the PR won't be merged without a proper changelog entry -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
